### PR TITLE
fix: TaskCard 배경색을 surfaceDark로 변경하여 배경과 구분

### DIFF
--- a/App/Views/Components/TaskCard.swift
+++ b/App/Views/Components/TaskCard.swift
@@ -13,6 +13,8 @@ enum TaskCardStyle {
 }
 
 struct TaskCard: View {
+  @Environment(\.colorScheme) private var colorScheme
+
   let task: Todo
   var style: TaskCardStyle = .normal
 
@@ -100,7 +102,9 @@ struct TaskCard: View {
       }
       .padding(12)
     }
-    .background(DesignSystem.Colors.surfaceDark)
+    .background(
+      colorScheme == .dark ? DesignSystem.Colors.surfaceDark : DesignSystem.Colors.surfaceLight,
+    )
     .clipShape(.rect(cornerRadius: 12))
     .shadow(color: .black.opacity(0.05), radius: 2, y: 1)
   }

--- a/App/Views/Components/TaskCard.swift
+++ b/App/Views/Components/TaskCard.swift
@@ -100,7 +100,7 @@ struct TaskCard: View {
       }
       .padding(12)
     }
-    .background(Color(nsColor: .controlBackgroundColor))
+    .background(DesignSystem.Colors.surfaceDark)
     .clipShape(.rect(cornerRadius: 12))
     .shadow(color: .black.opacity(0.05), radius: 2, y: 1)
   }


### PR DESCRIPTION
## 문제
보드 뷰에서 할일 카드가 배경과 구분되지 않아 가독성이 떨어지는 문제가 있었습니다.

## 변경 사항
- `TaskCard.swift`의 normalBody 배경색을 `Color(nsColor: .controlBackgroundColor)`에서 `DesignSystem.Colors.surfaceDark`로 변경

## 왜 이렇게 했나요?
- 디자인 레퍼런스에서 카드가 독립적인 표면으로 보여야 함
- `surfaceDark` (#2C2C2E)는 윈도우 배경과 구분되는 어두운 표면 색상

## 검증
- ✅ 빌드 성공
- ⬜ Board View 수동 검증 필요
- ⬜ Calendar View 컴팩트 카드 검증 필요