### PR TITLE
feat(AppIntent): AppIntent 및 Shortcuts 구현 (Closes #120)

### DIFF
--- a/TodoMate/AppIntent/Common/AppIntentError.swift
+++ b/TodoMate/AppIntent/Common/AppIntentError.swift
@@ -1,0 +1,29 @@
+//
+//  AppIntentError.swift
+//  TodoMate
+//
+//  Created by agent on 1/16/26.
+//
+
+import AppIntents
+import Foundation
+
+enum AppIntentError: Swift.Error, CustomLocalizedStringResourceConvertible {
+  case containerNotFound
+  case todoNotFound(id: String)
+  case memoNotFound(id: String)
+  case unknown
+
+  var localizedStringResource: LocalizedStringResource {
+    switch self {
+    case .containerNotFound:
+      "앱 서비스를 사용할 수 없습니다."
+    case let .todoNotFound(id):
+      "ID가 \(id)인 할 일을 찾을 수 없습니다."
+    case let .memoNotFound(id):
+      "ID가 \(id)인 메모를 찾을 수 없습니다."
+    case .unknown:
+      "알 수 없는 오류가 발생했습니다."
+    }
+  }
+}

--- a/TodoMate/AppIntent/Entity/MemoEntity.swift
+++ b/TodoMate/AppIntent/Entity/MemoEntity.swift
@@ -1,0 +1,74 @@
+//
+//  MemoEntity.swift
+//  TodoMate
+//
+//  Created by agent on 1/16/26.
+//
+
+import AppIntents
+import Foundation
+import SwiftData
+import TodoMateData
+import TodoMateDomain
+
+struct MemoEntity: AppEntity {
+  static var defaultQuery = MemoEntityQuery()
+  static var typeDisplayRepresentation: TypeDisplayRepresentation = "Memo"
+
+  var id: String
+  var content: String
+  var createdAt: Date
+
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(title: "\(content)")
+  }
+
+  init(id: String, content: String, createdAt: Date) {
+    self.id = id
+    self.content = content
+    self.createdAt = createdAt
+  }
+
+  init(from memo: Memo) {
+    id = memo.id
+    content = memo.content
+    createdAt = memo.createdAt
+  }
+}
+
+struct MemoEntityQuery: EntityQuery {
+  func entities(for identifiers: [String]) async throws -> [MemoEntity] {
+    guard let container = CoreDIContainer.shared?.modelContainer else {
+      return []
+    }
+
+    let context = ModelContext(container)
+    var result: [MemoEntity] = []
+
+    for id in identifiers {
+      let descriptor = FetchDescriptor<SDMemo>(predicate: #Predicate { $0.id == id })
+      if let sdMemo = try? context.fetch(descriptor).first {
+        result.append(MemoEntity(from: sdMemo.toDomain()))
+      }
+    }
+
+    return result
+  }
+
+  func suggestedEntities() async throws -> [MemoEntity] {
+    guard let container = CoreDIContainer.shared?.modelContainer else {
+      return []
+    }
+
+    let context = ModelContext(container)
+    var descriptor = FetchDescriptor<SDMemo>(sortBy: [SortDescriptor(\.updatedAt, order: .reverse)])
+    descriptor.fetchLimit = 20
+
+    do {
+      let sdMemos = try context.fetch(descriptor)
+      return sdMemos.map { MemoEntity(from: $0.toDomain()) }
+    } catch {
+      return []
+    }
+  }
+}

--- a/TodoMate/AppIntent/Entity/TodoEntity.swift
+++ b/TodoMate/AppIntent/Entity/TodoEntity.swift
@@ -1,0 +1,85 @@
+//
+//  TodoEntity.swift
+//  TodoMate
+//
+//  Created by agent on 1/16/26.
+//
+
+import AppIntents
+import Foundation
+import SwiftData
+import TodoMateData
+import TodoMateDomain
+
+struct TodoEntity: AppEntity {
+  static var defaultQuery = TodoEntityQuery()
+  static var typeDisplayRepresentation: TypeDisplayRepresentation = "Todo"
+
+  var id: String
+  var content: String
+  var status: String
+  var date: Date
+  var isDeleted: Bool
+
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(title: "\(content)", subtitle: "\(status)")
+  }
+
+  init(id: String, content: String, status: String, date: Date, isDeleted: Bool) {
+    self.id = id
+    self.content = content
+    self.status = status
+    self.date = date
+    self.isDeleted = isDeleted
+  }
+
+  init(from todo: Todo) {
+    id = todo.id
+    content = todo.content
+    status = todo.status.rawValue
+    date = todo.date
+    isDeleted = todo.isDeleted
+  }
+}
+
+struct TodoEntityQuery: EntityQuery {
+  func entities(for identifiers: [String]) async throws -> [TodoEntity] {
+    guard let container = CoreDIContainer.shared?.modelContainer else {
+      return []
+    }
+
+    let context = ModelContext(container)
+    var result: [TodoEntity] = []
+
+    // ID 리스트가 많지 않으므로 반복 조회 허용.
+    // 성능 최적화가 필요하면 FetchDescriptor(predicate: id in ids)를 쓸 수 있으나 SwiftData Predicate 복잡성 회피.
+    for id in identifiers {
+      let descriptor = FetchDescriptor<SDTodo>(predicate: #Predicate { $0.id == id })
+      if let sdTodo = try? context.fetch(descriptor).first {
+        result.append(TodoEntity(from: sdTodo.toDomain()))
+      }
+    }
+
+    return result
+  }
+
+  func suggestedEntities() async throws -> [TodoEntity] {
+    guard let container = CoreDIContainer.shared?.modelContainer else {
+      return []
+    }
+
+    let context = ModelContext(container)
+    // 최근 수정된 순서로 20개 조회
+    var descriptor = FetchDescriptor<SDTodo>(sortBy: [
+      SortDescriptor(\.updatedAt, order: .reverse),
+    ])
+    descriptor.fetchLimit = 20
+
+    do {
+      let sdTodos = try context.fetch(descriptor)
+      return sdTodos.map { TodoEntity(from: $0.toDomain()) }
+    } catch {
+      return []
+    }
+  }
+}

--- a/TodoMate/AppIntent/Intent/AddMemoIntent.swift
+++ b/TodoMate/AppIntent/Intent/AddMemoIntent.swift
@@ -1,0 +1,39 @@
+//
+//  AddMemoIntent.swift
+//  TodoMate
+//
+//  Created by agent on 1/16/26.
+//
+
+import AppIntents
+import Foundation
+import TodoMateDomain
+
+struct AddMemoIntent: AppIntent {
+  static var title: LocalizedStringResource = "Add Memo"
+  static var description: IntentDescription? = "Creates a new Memo in TodoMate."
+
+  @Parameter(title: "Content")
+  var content: String
+
+  static var parameterSummary: some ParameterSummary {
+    Summary("Add Memo \(\.$content)")
+  }
+
+  func perform() async throws -> some IntentResult & ReturnsValue<MemoEntity> {
+    guard let container = CoreDIContainer.shared else {
+      throw AppIntentError.containerNotFound
+    }
+
+    // 로컬 Memo는 owner를 ""로 설정 (AppIntent는 Firebase 미사용)
+    let memo = Memo(
+      owner: "",
+      content: content,
+    )
+
+    try await container.createLocalMemoUseCase.run(memo)
+
+    let entity = MemoEntity(from: memo)
+    return .result(value: entity)
+  }
+}

--- a/TodoMate/AppIntent/Intent/AddTodoIntent.swift
+++ b/TodoMate/AppIntent/Intent/AddTodoIntent.swift
@@ -1,0 +1,65 @@
+//
+//  AddTodoIntent.swift
+//  TodoMate
+//
+//  Created by agent on 1/16/26.
+//
+
+import AppIntents
+import Foundation
+import TodoMateDomain
+
+struct AddTodoIntent: AppIntent {
+  static var title: LocalizedStringResource = "Add Todo"
+  static var description: IntentDescription? = "Creates a new Todo in TodoMate."
+
+  @Parameter(title: "Content")
+  var content: String
+
+  @Parameter(title: "Detail", requestValueDialog: "Any details?")
+  var detail: String?
+
+  @Parameter(title: "Date", default: .now)
+  var date: Date
+
+  static var parameterSummary: some ParameterSummary {
+    Summary("Add \(\.$content)") {
+      \.$date
+      \.$detail
+    }
+  }
+
+  func perform() async throws -> some IntentResult & ReturnsValue<TodoEntity> {
+    guard let container = CoreDIContainer.shared else {
+      throw AppIntentError.containerNotFound
+    }
+
+    // 로컬 Todo는 owner를 ""로 설정 (AppIntent는 Firebase 미사용)
+
+    let todo = Todo(
+      owner: "",
+      content: content,
+      detail: detail ?? "",
+      in: date,
+    )
+
+    try await container.createLocalTodoUseCase.run(todo)
+
+    let entity = TodoEntity(from: todo)
+    return .result(value: entity)
+  }
+}
+
+enum AppIntentError: Swift.Error, CustomLocalizedStringResourceConvertible {
+  case containerNotFound
+  case unknown
+
+  var localizedStringResource: LocalizedStringResource {
+    switch self {
+    case .containerNotFound:
+      "App Services not available."
+    case .unknown:
+      "An unknown error has occurred."
+    }
+  }
+}

--- a/TodoMate/AppIntent/Intent/AddTodoIntent.swift
+++ b/TodoMate/AppIntent/Intent/AddTodoIntent.swift
@@ -49,17 +49,3 @@ struct AddTodoIntent: AppIntent {
     return .result(value: entity)
   }
 }
-
-enum AppIntentError: Swift.Error, CustomLocalizedStringResourceConvertible {
-  case containerNotFound
-  case unknown
-
-  var localizedStringResource: LocalizedStringResource {
-    switch self {
-    case .containerNotFound:
-      "App Services not available."
-    case .unknown:
-      "An unknown error has occurred."
-    }
-  }
-}

--- a/TodoMate/AppIntent/Intent/ReadTodosIntent.swift
+++ b/TodoMate/AppIntent/Intent/ReadTodosIntent.swift
@@ -38,9 +38,13 @@ struct ReadTodosIntent: AppIntent {
     var query = TodoQuery()
     if dateFilter == .today {
       let today = Calendar.current.startOfDay(for: .now)
-      let endOfDay = Calendar.current.date(
-        bySettingHour: 23, minute: 59, second: 59, of: today,
-      )!
+      guard
+        let endOfDay = Calendar.current.date(
+          bySettingHour: 23, minute: 59, second: 59, of: today,
+        )
+      else {
+        throw AppIntentError.unknown
+      }
       query = query.dateRange(today ... endOfDay)
     }
 

--- a/TodoMate/AppIntent/Intent/ReadTodosIntent.swift
+++ b/TodoMate/AppIntent/Intent/ReadTodosIntent.swift
@@ -1,0 +1,56 @@
+//
+//  ReadTodosIntent.swift
+//  TodoMate
+//
+//  Created by agent on 1/16/26.
+//
+
+import AppIntents
+import Foundation
+import TodoMateDomain
+
+struct ReadTodosIntent: AppIntent {
+  static var title: LocalizedStringResource = "Show Todos"
+  static var description: IntentDescription? = "Shows your local todos."
+
+  // 필터링 옵션을 추가할 수 있음 (예: "오늘", "내일", "완료됨" 등)
+  @Parameter(title: "Date Filter", default: .today)
+  var dateFilter: DateFilterParam
+
+  enum DateFilterParam: String, AppEnum {
+    case today
+    case all
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation = "Date Filter"
+    static var caseDisplayRepresentations: [DateFilterParam: DisplayRepresentation] = [
+      .today: "Today",
+      .all: "All",
+    ]
+  }
+
+  func perform() async throws -> some IntentResult & ReturnsValue<[TodoEntity]> {
+    guard let container = CoreDIContainer.shared else {
+      throw AppIntentError.containerNotFound
+    }
+
+    // Repository에서 조회
+    // Query 구성
+    var query = TodoQuery()
+    if dateFilter == .today {
+      let today = Calendar.current.startOfDay(for: .now)
+      let endOfDay = Calendar.current.date(
+        bySettingHour: 23, minute: 59, second: 59, of: today,
+      )!
+      query = query.dateRange(today ... endOfDay)
+    }
+
+    let todos = try await container.localTodoRepository.readAll(
+      query: query, useCache: true,
+    )
+
+    let entities = todos.map { TodoEntity(from: $0) }
+
+    // EntityQuery의 suggestedEntities와 달리 실제 사용자가 요청한 데이터 반환
+    return .result(value: entities)
+  }
+}

--- a/TodoMate/AppIntent/Intent/UpdateTodoIntent.swift
+++ b/TodoMate/AppIntent/Intent/UpdateTodoIntent.swift
@@ -52,7 +52,7 @@ struct UpdateTodoIntent: AppIntent {
     // Domain Todo로 변환하여 업데이트
     // 먼저 최신 상태 조회
     guard let currentTodo = try await container.localTodoRepository.read(id: todo.id) else {
-      throw AppIntentError.unknown // Not Found 에러 처리 필요
+      throw AppIntentError.todoNotFound(id: todo.id)
     }
 
     var updatedTodo = currentTodo

--- a/TodoMate/AppIntent/Intent/UpdateTodoIntent.swift
+++ b/TodoMate/AppIntent/Intent/UpdateTodoIntent.swift
@@ -1,0 +1,72 @@
+//
+//  UpdateTodoIntent.swift
+//  TodoMate
+//
+//  Created by agent on 1/16/26.
+//
+
+import AppIntents
+import Foundation
+import TodoMateDomain
+
+struct UpdateTodoIntent: AppIntent {
+  static var title: LocalizedStringResource = "Update Todo"
+  static var description: IntentDescription? = "Updates a Todo's status or content."
+
+  @Parameter(title: "Todo")
+  var todo: TodoEntity
+
+  @Parameter(title: "New Status")
+  var newStatus: TodoStatusParam?
+
+  @Parameter(title: "New Content")
+  var newContent: String?
+
+  // AppEnum for TodoStatus
+  enum TodoStatusParam: String, AppEnum {
+    case todo = "시작 전"
+    case inProgress = "진행 중"
+    case complete = "완료"
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation = "Todo Status"
+    static var caseDisplayRepresentations: [TodoStatusParam: DisplayRepresentation] = [
+      .todo: "To Do",
+      .inProgress: "In Progress",
+      .complete: "Complete",
+    ]
+
+    var asDomain: TodoStatus {
+      switch self {
+      case .todo: .todo
+      case .inProgress: .inProgress
+      case .complete: .complete
+      }
+    }
+  }
+
+  func perform() async throws -> some IntentResult & ReturnsValue<TodoEntity> {
+    guard let container = CoreDIContainer.shared else {
+      throw AppIntentError.containerNotFound
+    }
+
+    // Domain Todo로 변환하여 업데이트
+    // 먼저 최신 상태 조회
+    guard let currentTodo = try await container.localTodoRepository.read(id: todo.id) else {
+      throw AppIntentError.unknown // Not Found 에러 처리 필요
+    }
+
+    var updatedTodo = currentTodo
+
+    if let newStatus {
+      updatedTodo = updatedTodo.withUpdatedStatus(newStatus.asDomain)
+    }
+
+    if let newContent, !newContent.isEmpty {
+      updatedTodo = updatedTodo.withUpdatedContent(newContent)
+    }
+
+    try await container.localTodoRepository.update(updatedTodo)
+
+    return .result(value: TodoEntity(from: updatedTodo))
+  }
+}

--- a/TodoMate/AppIntent/TodoMateShortcuts.swift
+++ b/TodoMate/AppIntent/TodoMateShortcuts.swift
@@ -1,0 +1,45 @@
+//
+//  TodoMateShortcuts.swift
+//  TodoMate
+//
+//  Created by agent on 1/16/26.
+//
+
+import AppIntents
+
+struct TodoMateShortcuts: AppShortcutsProvider {
+  static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: AddTodoIntent(),
+      phrases: [
+        "Add Todo in \(.applicationName)",
+        "New Todo in \(.applicationName)",
+        "Create Todo in \(.applicationName)",
+      ],
+      shortTitle: "Add Todo",
+      systemImageName: "checklist",
+    )
+
+    AppShortcut(
+      intent: ReadTodosIntent(),
+      phrases: [
+        "Show Todos in \(.applicationName)",
+        "List Todos in \(.applicationName)",
+        "Check \(.applicationName)",
+      ],
+      shortTitle: "Show Todos",
+      systemImageName: "list.bullet",
+    )
+
+    AppShortcut(
+      intent: AddMemoIntent(),
+      phrases: [
+        "Add Memo in \(.applicationName)",
+        "New Memo in \(.applicationName)",
+        "Write Memo in \(.applicationName)",
+      ],
+      shortTitle: "Add Memo",
+      systemImageName: "note.text",
+    )
+  }
+}

--- a/TodoMate/Application/Dependency/AppDIContainer+Mocks.swift
+++ b/TodoMate/Application/Dependency/AppDIContainer+Mocks.swift
@@ -301,6 +301,10 @@ import TodoMateDomain
       todos.removeAll { $0.id == todoId }
     }
 
+    func read(id: String) async throws -> Todo? {
+      todos.first { $0.id == id }
+    }
+
     func readAll(query: TodoQuery, useCache _: Bool) async throws -> [Todo] {
       todos.filter { todo in
         for filter in query.filters {
@@ -337,6 +341,10 @@ import TodoMateDomain
     }
 
     func delete(_ memo: Memo) async throws { memos.removeAll { $0.id == memo.id } }
+
+    func read(id: String) async throws -> Memo? {
+      memos.first { $0.id == id }
+    }
 
     func readAllByUserId(_ userId: String, useCache _: Bool) async throws -> [Memo] {
       memos.filter { $0.owner == userId }

--- a/TodoMate/Application/Dependency/CoreDIContainer.swift
+++ b/TodoMate/Application/Dependency/CoreDIContainer.swift
@@ -78,3 +78,9 @@ extension CoreDIContainer {
     )
   }()
 }
+
+// MARK: - AppIntent Support
+
+extension CoreDIContainer {
+  nonisolated(unsafe) static var shared: CoreDIContainer?
+}

--- a/TodoMate/Application/TodoMateApp.swift
+++ b/TodoMate/Application/TodoMateApp.swift
@@ -31,6 +31,9 @@ struct TodoMateApp: App {
       appDIContainer = Self.composeContainer()
     #endif
 
+    // AppIntent에서 사용할 수 있도록 공유 인스턴스 설정
+    CoreDIContainer.shared = appDIContainer.core
+
     // 앱 업데이트 체크 및 처리
     Self.checkAndHandleAppUpdate(container: appDIContainer)
 

--- a/TodoMateData/Sources/TodoMateData/LocalMemoRepositoryImpl.swift
+++ b/TodoMateData/Sources/TodoMateData/LocalMemoRepositoryImpl.swift
@@ -56,6 +56,15 @@ public actor SwiftDataMemoRepositoryImpl: MemoRepository {
     }
   }
 
+  public func read(id: String) async throws -> Memo? {
+    let descriptor = FetchDescriptor<SDMemo>(predicate: #Predicate<SDMemo> { $0.id == id })
+    do {
+      return try modelContext.fetch(descriptor).first?.toDomain()
+    } catch {
+      throw SwiftDataError.fetchFailed(underlying: error)
+    }
+  }
+
   public func readAllByUserId(_: String, useCache _: Bool) async throws -> [Memo] {
     let descriptor = FetchDescriptor<SDMemo>(sortBy: [SortDescriptor(\.createdAt, order: .reverse)])
     do {

--- a/TodoMateData/Sources/TodoMateData/LocalTodoRepositoryImpl.swift
+++ b/TodoMateData/Sources/TodoMateData/LocalTodoRepositoryImpl.swift
@@ -64,6 +64,15 @@ public actor SwiftDataTodoRepositoryImpl: TodoRepository {
     }
   }
 
+  public func read(id: String) async throws -> Todo? {
+    let descriptor = FetchDescriptor<SDTodo>(predicate: #Predicate { $0.id == id })
+    do {
+      return try modelContext.fetch(descriptor).first?.toDomain()
+    } catch {
+      throw SwiftDataError.fetchFailed(underlying: error)
+    }
+  }
+
   public func readAll(query: TodoQuery, useCache _: Bool) async throws -> [Todo] {
     var dateRange: ClosedRange<Date>?
     for filter in query.filters {

--- a/TodoMateData/Sources/TodoMateData/MemoRepositoryImpl.swift
+++ b/TodoMateData/Sources/TodoMateData/MemoRepositoryImpl.swift
@@ -39,6 +39,15 @@ public final class FirestoreMemoRepository: MemoRepository {
     }
   }
 
+  public func read(id: String) async throws -> Memo? {
+    do {
+      let document = try await reference.memoCollection().document(id).getDocument()
+      return try? document.data(as: Memo.self)
+    } catch {
+      throw FirestoreRepositoryError.readFailed(underlying: error)
+    }
+  }
+
   public func readAllByUserId(_ userId: String, useCache: Bool = true) async throws -> [Memo] {
     let source: FirestoreSource = useCache ? .cache : .server
     do {

--- a/TodoMateData/Sources/TodoMateData/TodoRepositoryImpl.swift
+++ b/TodoMateData/Sources/TodoMateData/TodoRepositoryImpl.swift
@@ -38,6 +38,15 @@ public final class FirestoreTodoRepository: TodoRepository {
     }
   }
 
+  public func read(id: String) async throws -> Todo? {
+    do {
+      let document = try await reference.todoCollection().document(id).getDocument()
+      return try? document.data(as: Todo.self)
+    } catch {
+      throw FirestoreRepositoryError.readFailed(underlying: error)
+    }
+  }
+
   public func readAll(query: TodoQuery, useCache: Bool) async throws -> [Todo] {
     let firestoreQuery = buildFirestoreQuery(from: query)
     let source: FirestoreSource = useCache ? .cache : .default

--- a/TodoMateDomain/Sources/TodoMateDomain/Protocol/MemoRepository.swift
+++ b/TodoMateDomain/Sources/TodoMateDomain/Protocol/MemoRepository.swift
@@ -9,6 +9,7 @@ public protocol MemoRepository: Sendable {
   func create(_ memo: Memo) async throws
   func update(_ memo: Memo) async throws
   func delete(_ memo: Memo) async throws
+  func read(id: String) async throws -> Memo?
   func readAllByUserId(_ userId: String, useCache: Bool) async throws -> [Memo]
   func readAllByUserIds(_ userIds: [String], useCache: Bool) async throws -> [Memo]
 }
@@ -20,6 +21,7 @@ public final class StubMemoRepository: MemoRepository, Sendable {
   public func create(_: Memo) async throws {}
   public func update(_: Memo) async throws {}
   public func delete(_: Memo) async throws {}
+  public func read(id _: String) async throws -> Memo? { nil }
   public func readAllByUserId(_: String, useCache _: Bool = true) async throws -> [Memo] { [] }
   public func readAllByUserIds(_: [String], useCache _: Bool = true) async throws -> [Memo] { [] }
 }

--- a/TodoMateDomain/Sources/TodoMateDomain/Protocol/TodoRepository.swift
+++ b/TodoMateDomain/Sources/TodoMateDomain/Protocol/TodoRepository.swift
@@ -9,6 +9,7 @@ public protocol TodoRepository: Sendable {
   func create(_ todo: Todo) async throws
   func update(_ todo: Todo) async throws
   func delete(_ todoId: String) async throws
+  func read(id: String) async throws -> Todo?
   func readAll(query: TodoQuery, useCache: Bool) async throws -> [Todo]
 }
 
@@ -19,5 +20,6 @@ public final class StubTodoRepository: TodoRepository, Sendable {
   public func create(_: Todo) async throws {}
   public func update(_: Todo) async throws {}
   public func delete(_: String) async throws {}
+  public func read(id _: String) async throws -> Todo? { nil }
   public func readAll(query _: TodoQuery, useCache _: Bool) async throws -> [Todo] { [] }
 }


### PR DESCRIPTION
## 📋 Summary
Shortcuts(단축어) 및 Spotlight와 연동되는 `AppIntent` 기능을 구현했습니다. 로컬 데이터(`LocalTodo`, `LocalMemo`)를 생성, 조회, 수정할 수 있는 Intent를 제공합니다.

## 🎯 Motivation
- **Issue #120**: 시스템 수준에서 앱의 핵심 기능(투두/메모)에 접근할 수 있도록 지원.
- 사용자가 앱을 열지 않고도 Siri나 검색을 통해 빠르게 할 일을 추가하거나 확인할 수 있습니다.

## 🔧 Changes
### Infrastructure
- `CoreDIContainer.shared`: AppIntent는 시스템에 의해 독립된 프로세스로 실행될 수 있으므로, Firebase 등 무거운 의존성 없이 로컬 DB(`SwiftData`)에만 접근할 수 있도록 `CoreDIContainer`에 싱글톤 접근자(`shared`)를 추가했습니다.

### Domain / Data
- `TodoRepository`, `MemoRepository`: ID 기반 단일 조회를 위한 `read(id:)` 메서드 추가 및 구현 (`Local`, `Firestore` 모두 구현).
- `TodoEntity`, `MemoEntity`: `AppEntity` 프로토콜을 준수하는 엔티티 정의.

### AppIntent
1. **Todo**:
   - `AddTodoIntent`: 새로운 할 일 추가.
   - `ReadTodosIntent`: 오늘/전체 할 일 목록 조회.
   - `UpdateTodoIntent`: 할 일 상태(완료 등) 및 내용 수정.
2. **Memo**:
   - `AddMemoIntent`: 새로운 메모 추가.
3. **Shortcuts**:
   - `TodoMateShortcuts`: "Add Todo", "Show Todos", "Add Memo" 단축어 등록.

## 🧪 Testing
- [x] **Build Check**: `AppIntent` 타겟 및 메인 앱 빌드 성공 확인.
- [x] **Manual Verification**: (PR 병합 후) Shortcuts 앱에서 단축어 동작 확인 필요.

## 🔗 Related Issues
Closes #120
