### PR TITLE
feat: Implement In-Progress indicator for Group Feed

### DIFF
--- a/TodoMate/Features/Public/Group/Components/SharedTodoRow.swift
+++ b/TodoMate/Features/Public/Group/Components/SharedTodoRow.swift
@@ -12,9 +12,9 @@ struct SharedTodoRow: View {
 
   var body: some View {
     HStack(alignment: .top, spacing: 12) {
-      Image(systemName: iconName)
+      Image(systemName: todo.status.toDomainStatus().iconName)
         .font(.system(size: 20))
-        .foregroundStyle(iconColor)
+        .foregroundStyle(todo.status.toDomainStatus().color)
 
       VStack(alignment: .leading, spacing: 4) {
         Text(todo.content)
@@ -43,24 +43,6 @@ struct SharedTodoRow: View {
     }
     .padding(.horizontal, 16)
     .padding(.vertical, 12)
-  }
-
-  private var iconName: String {
-    switch todo.status {
-    case .done: "checkmark.circle.fill"
-    case .inProgress: "circle.inset.filled"
-    case .inComplete: "xmark.circle.fill"
-    case .todo: "circle"
-    }
-  }
-
-  private var iconColor: Color {
-    switch todo.status {
-    case .done: .blue
-    case .inProgress: .blue
-    case .inComplete: .red
-    case .todo: .gray.opacity(0.3)
-    }
   }
 
   func tagColor(for tag: String) -> Color {

--- a/TodoMate/Features/Public/Group/Components/SharedTodoRow.swift
+++ b/TodoMate/Features/Public/Group/Components/SharedTodoRow.swift
@@ -12,9 +12,9 @@ struct SharedTodoRow: View {
 
   var body: some View {
     HStack(alignment: .top, spacing: 12) {
-      Image(systemName: todo.status == .done ? "checkmark.circle.fill" : "circle")
+      Image(systemName: iconName)
         .font(.system(size: 20))
-        .foregroundStyle(todo.status == .done ? .blue : .gray.opacity(0.3))
+        .foregroundStyle(iconColor)
 
       VStack(alignment: .leading, spacing: 4) {
         Text(todo.content)
@@ -45,6 +45,24 @@ struct SharedTodoRow: View {
     .padding(.vertical, 12)
   }
 
+  private var iconName: String {
+    switch todo.status {
+    case .done: "checkmark.circle.fill"
+    case .inProgress: "circle.inset.filled"
+    case .inComplete: "xmark.circle.fill"
+    case .todo: "circle"
+    }
+  }
+
+  private var iconColor: Color {
+    switch todo.status {
+    case .done: .blue
+    case .inProgress: .blue
+    case .inComplete: .red
+    case .todo: .gray.opacity(0.3)
+    }
+  }
+
   func tagColor(for tag: String) -> Color {
     switch tag.lowercased() {
     case "high": .red
@@ -69,6 +87,13 @@ struct SharedTodoRow: View {
         content: "Completed Task",
         status: .done,
         tags: ["System"],
+      ))
+    SharedTodoRow(
+      todo: ViewTodo(
+        owner: "user1",
+        content: "In Progress Task",
+        status: .inProgress,
+        tags: [],
       ))
   }
 }


### PR DESCRIPTION
Implements specific icon and color logic for `inProgress` status in `SharedTodoRow` using `circle.inset.filled` and `.blue` respectively.

This change enhances the visual distinction of in-progress tasks in the group feed.