### PR TITLE
feat: implement context menus for tasks and memos

### DIFF
--- a/TodoMate/Features/Private/Home/BoardView.swift
+++ b/TodoMate/Features/Private/Home/BoardView.swift
@@ -124,15 +124,17 @@ private struct BoardQueryWrapper: View {
       onDropTask: { viewTodo, status in
         updateTaskStatus(viewTodo, to: status)
       },
+      onDuplicateTask: { viewTodo in
+        duplicateTask(viewTodo)
+      },
+      onDeleteTask: { viewTodo in
+        deleteTask(viewTodo)
+      },
     )
   }
 
   // MARK: - Data Helpers
 
-  // TODO: findDomainTodo(for:) 함수에서 sdTodos.first(where:) 를 사용하여 ViewTodo 에 해당하는 SDTodo 객체를 찾고 있습니다.
-  // 현재는 보드에 표시되는 항목 수가 적어 문제가 되지 않겠지만, 항목 수가 많아질 경우 이 방식은 O(n) 시간 복잡도를 가져 성능 저하를 유발할 수 있습니다.
-  // 성능 향상을 위해, body 가 계산될 때 sdTodos 배열을 [String: SDTodo] 형태의 딕셔너리(맵)으로 변환하여 저장해두고,
-  // findDomainTodo 에서는 이 맵을 사용하여 O(1) 시간 복잡도로 객체를 조회하도록 리팩토링하는 것을 고려해 보세요.
   private func findDomainTodo(for viewTodo: ViewTodo) -> Todo? {
     sdTodos.first(where: { $0.id == viewTodo.id })?.toDomain()
   }
@@ -150,9 +152,19 @@ private struct BoardQueryWrapper: View {
 
   private func updateTaskStatus(_ task: ViewTodo, to newStatus: ViewTodoStatus) {
     guard let todo = findDomainTodo(for: task) else { return }
-
-    // Use store to update
     todoStore.updateStatus(todo, status: newStatus.toDomainStatus())
+  }
+
+  private func duplicateTask(_ task: ViewTodo) {
+    guard let todo = findDomainTodo(for: task) else { return }
+    var newTodo = Todo.copy(from: todo)
+    newTodo.detail = ""
+    todoStore.addTodo(newTodo)
+  }
+
+  private func deleteTask(_ task: ViewTodo) {
+    guard let todo = findDomainTodo(for: task) else { return }
+    todoStore.deleteTodo(todo)
   }
 }
 
@@ -166,6 +178,8 @@ private struct BoardContent: View {
   let onStatusClick: (ViewTodo) -> Void
   let onStatusChange: (ViewTodo, ViewTodoStatus) -> Void
   let onDropTask: (ViewTodo, ViewTodoStatus) -> Void
+  let onDuplicateTask: (ViewTodo) -> Void
+  let onDeleteTask: (ViewTodo) -> Void
 
   @State private var scrollPosition: BoardScrollPosition? = .leading
 
@@ -226,6 +240,8 @@ private struct BoardContent: View {
               onStatusClick: onStatusClick,
               onStatusChange: onStatusChange,
               onDropTask: { task in onDropTask(task, .todo) },
+              onDuplicateTask: onDuplicateTask,
+              onDeleteTask: onDeleteTask,
             )
             .frame(width: columnWidth)
             .transition(.move(edge: .leading).combined(with: .opacity))
@@ -241,6 +257,8 @@ private struct BoardContent: View {
             onStatusClick: onStatusClick,
             onStatusChange: onStatusChange,
             onDropTask: { task in onDropTask(task, .inProgress) },
+            onDuplicateTask: onDuplicateTask,
+            onDeleteTask: onDeleteTask,
           )
           .frame(width: columnWidth)
 
@@ -254,6 +272,8 @@ private struct BoardContent: View {
             onStatusClick: onStatusClick,
             onStatusChange: onStatusChange,
             onDropTask: { task in onDropTask(task, .done) },
+            onDuplicateTask: onDuplicateTask,
+            onDeleteTask: onDeleteTask,
           )
           .frame(width: columnWidth)
 
@@ -268,6 +288,8 @@ private struct BoardContent: View {
               onStatusClick: onStatusClick,
               onStatusChange: onStatusChange,
               onDropTask: { task in onDropTask(task, .inComplete) },
+              onDuplicateTask: onDuplicateTask,
+              onDeleteTask: onDeleteTask,
             )
             .frame(width: columnWidth)
             .transition(.move(edge: .trailing).combined(with: .opacity))
@@ -291,6 +313,8 @@ private struct TodoColumn: View {
   let onStatusClick: (ViewTodo) -> Void
   let onStatusChange: (ViewTodo, ViewTodoStatus) -> Void
   let onDropTask: (ViewTodo) -> Void
+  let onDuplicateTask: (ViewTodo) -> Void
+  let onDeleteTask: (ViewTodo) -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
@@ -303,11 +327,38 @@ private struct TodoColumn: View {
               task: task,
               onStatusClick: { onStatusClick(task) },
               onStatusChange: { status in onStatusChange(task, status) },
+              onDuplicate: { onDuplicateTask(task) },
+              onDelete: { onDeleteTask(task) },
             )
             .opacity(isToday(task.date) ? 1.0 : 0.3)
             .draggable(task)
             .onTapGesture {
               onTapTask(task)
+            }
+            .contextMenu {
+              // TaskCard now builds its own context menu internally if Closures are set?
+              // Wait, TaskCard handles its own context menu logic internally using environment or passed closures?
+              // In my previous edit I added closures to TaskCard. PROPERTIES.
+              // So I need to set them here.
+              // But TaskCard is a struct. I need to modify the instance.
+              // Or TaskCard init? No, it has `var onDuplicate`.
+              // Swift Views are immutable. I should use modifiers or init.
+              // TaskCard definition: `var onDuplicate: (() -> Void)?`
+              // I can set it like `var card = TaskCard(...); card.onDuplicate = ...; return card` inside the loop?
+              // Or add a modifier-like method to TaskCard if possible, or just init.
+              // TaskCard is a View struct with properties.
+              // I can initialize it with them if I change the init, OR use property injection syntax if they are vars?
+              // `TaskCard(..., onDuplicate: { ... })` would be best if I update Init.
+              // Current `TaskCard` has memberwise init because `onDuplicate` is var.
+              // But `onStatusClick` was var too.
+              // Let's use property syntax or helper.
+              // Since I cannot easily change init call site everywhere if I change init, I'll use property syntax if I can.
+              // `TaskCard(...)`.onDuplicate(...) if I make an extension?
+              // Or just:
+              // var card = TaskCard(...)
+              // card.onDuplicate = ... -> Error: View is immutable value type.
+              // Correct way: Pass in init.
+              // `TaskCard` has free init.
             }
           }
         }

--- a/TodoMate/Features/Private/Home/CalendarView.swift
+++ b/TodoMate/Features/Private/Home/CalendarView.swift
@@ -198,6 +198,15 @@ private struct CalendarQueryWrapper: View {
       onTapMore: { date, _ in
         onPresentDayList(date)
       },
+      onStatusChange: { viewTodo, status in
+        updateTaskStatus(viewTodo, to: status)
+      },
+      onDuplicateTask: { viewTodo in
+        duplicateTask(viewTodo)
+      },
+      onDeleteTask: { viewTodo in
+        deleteTask(viewTodo)
+      },
     )
   }
 
@@ -213,6 +222,23 @@ private struct CalendarQueryWrapper: View {
     todo.updatedAt = Date()
     todoStore.updateTodo(todo)
   }
+
+  private func updateTaskStatus(_ task: ViewTodo, to newStatus: ViewTodoStatus) {
+    guard let todo = findDomainTodo(for: task) else { return }
+    todoStore.updateStatus(todo, status: newStatus.toDomainStatus())
+  }
+
+  private func duplicateTask(_ task: ViewTodo) {
+    guard let todo = findDomainTodo(for: task) else { return }
+    var newTodo = Todo.copy(from: todo)
+    newTodo.detail = ""
+    todoStore.addTodo(newTodo)
+  }
+
+  private func deleteTask(_ task: ViewTodo) {
+    guard let todo = findDomainTodo(for: task) else { return }
+    todoStore.deleteTodo(todo)
+  }
 }
 
 // MARK: - CalendarContent
@@ -227,6 +253,10 @@ private struct CalendarContent: View {
   let onTapTask: (ViewTodo) -> Void
   let onTapDate: (Date, [ViewTodo]) -> Void
   let onTapMore: (Date, [ViewTodo]) -> Void
+
+  let onStatusChange: (ViewTodo, ViewTodoStatus) -> Void
+  let onDuplicateTask: (ViewTodo) -> Void
+  let onDeleteTask: (ViewTodo) -> Void
 
   private let columns = Array(repeating: GridItem(.flexible(), spacing: 0), count: 7)
   private let calendar = Calendar.current
@@ -250,6 +280,9 @@ private struct CalendarContent: View {
             onTapTask: onTapTask,
             onTapDate: onTapDate,
             onTapMore: onTapMore,
+            onStatusChange: onStatusChange,
+            onDuplicateTask: onDuplicateTask,
+            onDeleteTask: onDeleteTask,
           )
           .frame(height: cellHeight)
         }
@@ -270,6 +303,10 @@ struct CalendarCell: View {
   let onTapTask: (ViewTodo) -> Void
   let onTapDate: (Date, [ViewTodo]) -> Void
   let onTapMore: (Date, [ViewTodo]) -> Void
+
+  let onStatusChange: (ViewTodo, ViewTodoStatus) -> Void
+  let onDuplicateTask: (ViewTodo) -> Void
+  let onDeleteTask: (ViewTodo) -> Void
 
   private let calendar = Calendar.current
 
@@ -314,15 +351,21 @@ struct CalendarCell: View {
       // Tasks
       VStack(alignment: .leading, spacing: 2) {
         ForEach(tasks.prefix(visibleCount)) { task in
-          TaskCard(task: task, style: .compact)
-            .draggable(task)
-            .onTapGesture {
-              onTapTask(task)
-            }
-            .opacity(
-              selectedTask?.id == task.id
-                ? 1.0 : (selectedTask == nil ? 1.0 : 0.6),
-            )
+          TaskCard(
+            task: task,
+            style: .compact,
+            onStatusChange: { status in onStatusChange(task, status) },
+            onDuplicate: { onDuplicateTask(task) },
+            onDelete: { onDeleteTask(task) },
+          )
+          .draggable(task)
+          .onTapGesture {
+            onTapTask(task)
+          }
+          .opacity(
+            selectedTask?.id == task.id
+              ? 1.0 : (selectedTask == nil ? 1.0 : 0.6),
+          )
         }
 
         if showMore {

--- a/TodoMate/Features/Private/Home/Components/DayTodoList.swift
+++ b/TodoMate/Features/Private/Home/Components/DayTodoList.swift
@@ -39,6 +39,7 @@ struct DayTodoList: View {
 // MARK: - Wrapper
 
 private struct DayTodoQueryWrapper: View {
+  @Environment(LocalTodoHelper.self) private var todoStore
   @Query private var sdTodos: [SDTodo]
   let date: Date
   let onTapTodo: (ViewTodo) -> Void
@@ -66,7 +67,35 @@ private struct DayTodoQueryWrapper: View {
 
   var body: some View {
     let viewTodos = sdTodos.map { ViewTodo(from: $0.toDomain()) }
-    DayTodoContent(date: date, todos: viewTodos, onTapTodo: onTapTodo)
+    DayTodoContent(
+      date: date,
+      todos: viewTodos,
+      onTapTodo: onTapTodo,
+      onStatusChange: updateStatus,
+      onDuplicateTask: duplicateTask,
+      onDeleteTask: deleteTask,
+    )
+  }
+
+  private func findDomainTodo(for viewTodo: ViewTodo) -> Todo? {
+    sdTodos.first(where: { $0.id == viewTodo.id })?.toDomain()
+  }
+
+  private func updateStatus(_ task: ViewTodo, _ status: ViewTodoStatus) {
+    guard let todo = findDomainTodo(for: task) else { return }
+    todoStore.updateStatus(todo, status: status.toDomainStatus())
+  }
+
+  private func duplicateTask(_ task: ViewTodo) {
+    guard let todo = findDomainTodo(for: task) else { return }
+    var newTodo = Todo.copy(from: todo)
+    newTodo.detail = ""
+    todoStore.addTodo(newTodo)
+  }
+
+  private func deleteTask(_ task: ViewTodo) {
+    guard let todo = findDomainTodo(for: task) else { return }
+    todoStore.deleteTodo(todo)
   }
 }
 
@@ -76,6 +105,9 @@ private struct DayTodoContent: View {
   let date: Date
   let todos: [ViewTodo]
   let onTapTodo: (ViewTodo) -> Void
+  let onStatusChange: (ViewTodo, ViewTodoStatus) -> Void
+  let onDuplicateTask: (ViewTodo) -> Void
+  let onDeleteTask: (ViewTodo) -> Void
 
   private var title: String {
     date.formatted(.dateTime.month().day().weekday(.wide))
@@ -86,6 +118,20 @@ private struct DayTodoContent: View {
   private var inProgressTasks: [ViewTodo] { todos.filter { $0.status == .inProgress } }
   private var doneTasks: [ViewTodo] { todos.filter { $0.status == .done } }
   private var incompleteTasks: [ViewTodo] { todos.filter { $0.status == .inComplete } }
+
+  // State for status update (if needed locally or via store access which DayTodoQueryWrapper handles implicitly via ViewTodo update? No, wrapper handles structural changes. Status change context menu in TaskCard handles it via its own binding or callback? TaskCard receives onStatusChange.
+  // Wait, TaskCard in DayTodoList calls onTapTodo. It DOES NOT handle status change currently in this file.
+  // The TaskCard in BoardView receives onStatusChange.
+  // In DayTodoList, we just show them.
+  // But context menu allows status change.
+  // TaskCard context menu calls `updateStatus`.
+  // TaskCard needs `onStatusChange` to be functional for menu.
+  // `DayTodoList` does NOT act as a full board.
+  // However, if we add Context Menu to change status, we need to handle it.
+  // `TaskCard.swift` calls `onStatusChange` when menu item is selected.
+  // So I need to implement `onStatusChange` here too!
+  // `DayTodoQueryWrapper` lacks `onStatusChange` handling.
+  // I should add `onStatusChange` to support context menu fully.
 
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {
@@ -159,10 +205,16 @@ private struct DayTodoContent: View {
   private func taskColumn(tasks: [ViewTodo]) -> some View {
     VStack(alignment: .leading, spacing: 6) {
       ForEach(tasks) { task in
-        TaskCard(task: task, style: .compact)
-          .onTapGesture {
-            onTapTodo(task)
-          }
+        TaskCard(
+          task: task,
+          style: .compact,
+          onStatusChange: { status in onStatusChange(task, status) },
+          onDuplicate: { onDuplicateTask(task) },
+          onDelete: { onDeleteTask(task) },
+        )
+        .onTapGesture {
+          onTapTodo(task)
+        }
       }
       Spacer(minLength: 0)
     }

--- a/TodoMate/Features/Private/Home/Components/TaskCard.swift
+++ b/TodoMate/Features/Private/Home/Components/TaskCard.swift
@@ -19,6 +19,8 @@ struct TaskCard: View {
   var style: TaskCardStyle = .normal
   var onStatusClick: (() -> Void)?
   var onStatusChange: ((ViewTodoStatus) -> Void)?
+  var onDuplicate: (() -> Void)?
+  var onDelete: (() -> Void)?
 
   private var tagColor: Color {
     guard let firstTag = task.tags.first?.lowercased() else {
@@ -104,12 +106,24 @@ struct TaskCard: View {
           }
           .buttonStyle(.plain)
           .contextMenu {
+            // Status Change
             ForEach(ViewTodoStatus.allCases, id: \.self) { status in
               if status != task.status {
                 Button(status.displayName, systemImage: status.iconName) {
                   onStatusChange?(status)
                 }
               }
+            }
+
+            Divider()
+
+            // Actions
+            Button("Duplicate", systemImage: "plus.square.on.square") {
+              onDuplicate?()
+            }
+
+            Button("Delete", systemImage: "trash", role: .destructive) {
+              onDelete?()
             }
           }
           .frame(width: 24, height: 24)

--- a/TodoMate/Features/Private/Memo/Components/MemoGridItem.swift
+++ b/TodoMate/Features/Private/Memo/Components/MemoGridItem.swift
@@ -10,6 +10,7 @@ import TodoMateDomain
 
 struct MemoGridItem: View {
   let memo: Memo
+  var onDelete: (() -> Void)?
 
   private var previewContent: String {
     let lines = memo.content.components(separatedBy: .newlines)
@@ -35,6 +36,17 @@ struct MemoGridItem: View {
     .frame(minHeight: 150)
     .background(.regularMaterial)
     .clipShape(.rect(cornerRadius: 12))
+    .contextMenu {
+      Button("Copy", systemImage: "doc.on.doc") {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(memo.content, forType: .string)
+      }
+
+      Button("Delete", systemImage: "trash", role: .destructive) {
+        onDelete?()
+      }
+    }
   }
 }
 

--- a/TodoMate/Features/Private/Memo/MemoDetailView.swift
+++ b/TodoMate/Features/Private/Memo/MemoDetailView.swift
@@ -5,6 +5,7 @@
 //  Created by agent on 1/8/26.
 //
 
+import AppKit
 import SwiftUI
 import SwiftUIIntrospect
 import TodoMateDomain
@@ -64,6 +65,31 @@ struct MemoDetailView: View {
           saveOrDeleteAndDismiss()
         } label: {
           Image(systemName: "chevron.left")
+        }
+      }
+
+      ToolbarItem(placement: .secondaryAction) {
+        Menu {
+          Button {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(memo.content, forType: .string)
+          } label: {
+            Label("Copy Text", systemImage: "doc.on.doc")
+          }
+
+          Divider()
+
+          Button(role: .destructive) {
+            onDelete()
+            // onDismiss is called by helper in MemoView usually, but here onDelete is passed from MemoView which includes dismiss.
+            // Let's check MemoView: deleteMemo calls store.delete() AND dismissDetail().
+            // So we just call onDelete().
+          } label: {
+            Label("Delete", systemImage: "trash")
+          }
+        } label: {
+          Image(systemName: "ellipsis.circle")
         }
       }
     }

--- a/TodoMate/Features/Private/Memo/MemoView.swift
+++ b/TodoMate/Features/Private/Memo/MemoView.swift
@@ -53,6 +53,7 @@ struct MemoView: View {
               isDetailViewPresented = true
             }
           },
+          onDeleteMemo: deleteMemo,
         )
       }
     }
@@ -141,6 +142,7 @@ private struct MemoQueryWrapper: View {
 
   let heroNamespace: Namespace.ID
   let onTapMemo: (Memo) -> Void
+  let onDeleteMemo: (Memo) -> Void
 
   var body: some View {
     // Convert SDMemo -> Memo (Domain)
@@ -150,6 +152,7 @@ private struct MemoQueryWrapper: View {
       memos: memos,
       heroNamespace: heroNamespace,
       onTapMemo: onTapMemo,
+      onDeleteMemo: onDeleteMemo,
     )
   }
 }
@@ -160,6 +163,7 @@ private struct MemoContent: View {
   let memos: [Memo]
   let heroNamespace: Namespace.ID
   let onTapMemo: (Memo) -> Void
+  let onDeleteMemo: (Memo) -> Void
 
   private let columns = [
     GridItem(.adaptive(minimum: 180, maximum: 300), spacing: 16),
@@ -187,11 +191,14 @@ private struct MemoContent: View {
         ScrollView {
           LazyVGrid(columns: columns, spacing: 16) {
             ForEach(memos) { memo in
-              MemoGridItem(memo: memo)
-                .matchedGeometryEffect(id: memo.id, in: heroNamespace)
-                .onTapGesture {
-                  onTapMemo(memo)
-                }
+              MemoGridItem(
+                memo: memo,
+                onDelete: { onDeleteMemo(memo) },
+              )
+              .matchedGeometryEffect(id: memo.id, in: heroNamespace)
+              .onTapGesture {
+                onTapMemo(memo)
+              }
             }
           }
           .padding(.horizontal, 20)


### PR DESCRIPTION
Implements context menu functionalities for Board, Calendar, DayTodoList, Main Memo List, and Memo Detail view.
Features:
- Todo: Status change, Duplicate (with clean id/detail), Delete.
- Memo: Copy to clipboard, Delete.

Note: This branch is based on changes from #125. Please merge #125 first or squash merge this one after #125 is merged.