### PR TITLE
fix: refactor sync logic for better concurrency

### DIFF
--- a/TodoMate/Features/Public/Group/GroupFeedView.swift
+++ b/TodoMate/Features/Public/Group/GroupFeedView.swift
@@ -205,18 +205,10 @@ struct GroupFeedView: View {
         appDI.core.sidebarCacheUseCase.saveGroup(name: group.name, id: group.id)
       }
     }
-    .task {
+    .task(id: isPublicModeEnabled) {
+      guard isPublicModeEnabled else { return }
       guard sessionStore.isAuthenticated, !sessionStore.userId.isEmpty else { return }
-      if isPublicModeEnabled {
-        await refreshData()
-      }
-    }
-    .onChange(of: isPublicModeEnabled) { _, isEnabled in
-      if isEnabled {
-        Task {
-          await refreshData()
-        }
-      }
+      await refreshData()
     }
     .onChange(of: sessionStore.currentGroup) { _, group in
       if let group {


### PR DESCRIPTION
Refactors GroupFeedView sync logic to use .task(id:) instead of .task + .onChange.\n\nBenefits:\n- Prevents race conditions\n- Automatically cancels outdated tasks\n- Correctly scopes task lifecycle to view