### PR TITLE
fix: Optimize Sidebar counts and Implement Soft Delete

### DIFF
--- a/.agent/rules/git-conventions.md
+++ b/.agent/rules/git-conventions.md
@@ -107,3 +107,6 @@ merge: feature/study-session into main
 ### 4. After Rebase
 - Resolve conflicts carefully without changing original intent.
 - Run tests to ensure behavior is unchanged.
+
+## Do not commit .test-logs/
+- It's used only in Debug for Agent.

--- a/.test-logs/build.log
+++ b/.test-logs/build.log
@@ -1,3 +1,0 @@
---- xcodebuild: WARNING: Using the first of multiple matching destinations:
-{ platform:macOS, arch:arm64, id:00008112-000D58EE0CDBC01E, name:My Mac }
-{ platform:macOS, arch:x86_64, id:00008112-000D58EE0CDBC01E, name:My Mac }

--- a/TodoMate/Application/Dependency/AppDIContainer+Mocks.swift
+++ b/TodoMate/Application/Dependency/AppDIContainer+Mocks.swift
@@ -322,6 +322,25 @@ import TodoMateDomain
         return true
       }
     }
+
+    func fetchCount(query: TodoQuery) async throws -> Int {
+      let filtered = todos.filter { todo in
+        for filter in query.filters {
+          switch filter {
+          case let .owner(userId):
+            if todo.owner != userId { return false }
+          case let .owners(userIds):
+            if !userIds.contains(todo.owner) { return false }
+          case let .dateRange(range):
+            if !range.contains(todo.date) { return false }
+          case let .status(status):
+            if todo.status != status { return false }
+          }
+        }
+        return true
+      }
+      return filtered.count
+    }
   }
 
   final class MockMemoRepository: MemoRepository, @unchecked Sendable {
@@ -352,6 +371,10 @@ import TodoMateDomain
 
     func readAllByUserIds(_ userIds: [String], useCache _: Bool) async throws -> [Memo] {
       memos.filter { userIds.contains($0.owner) }
+    }
+
+    func fetchCount(userId: String) async throws -> Int {
+      memos.count(where: { $0.owner == userId && !$0.isDeleted })
     }
   }
 

--- a/TodoMate/Application/Dependency/CoreDIContainer.swift
+++ b/TodoMate/Application/Dependency/CoreDIContainer.swift
@@ -33,6 +33,9 @@ final class CoreDIContainer {
   @ObservationIgnored let updateLocalMemoUseCase: UpdateLocalMemoUseCase
   @ObservationIgnored let deleteLocalMemoUseCase: DeleteLocalMemoUseCase
 
+  @ObservationIgnored let fetchTodoCountUseCase: FetchTodoCountUseCase
+  @ObservationIgnored let fetchMemoCountUseCase: FetchMemoCountUseCase
+
   init(
     modelContainer: ModelContainer,
     userDefaults: UserDefaults = .standard,
@@ -59,6 +62,9 @@ final class CoreDIContainer {
     readLocalMemoUseCase = ReadLocalMemoUseCaseImpl(repository: localMemoRepository)
     updateLocalMemoUseCase = UpdateLocalMemoUseCaseImpl(repository: localMemoRepository)
     deleteLocalMemoUseCase = DeleteLocalMemoUseCaseImpl(repository: localMemoRepository)
+
+    fetchTodoCountUseCase = FetchTodoCountUseCaseImpl(repository: localTodoRepository)
+    fetchMemoCountUseCase = FetchMemoCountUseCaseImpl(repository: localMemoRepository)
 
     sidebarCacheRepository = SidebarCacheRepositoryImpl(userDefaults: userDefaults)
     sidebarCacheUseCase = SidebarCacheUseCaseImpl(repository: sidebarCacheRepository)

--- a/TodoMate/Features/Main/Sidebar.swift
+++ b/TodoMate/Features/Main/Sidebar.swift
@@ -13,6 +13,8 @@ import TodoMateDomain
 
 struct Sidebar: View {
   @Environment(AppDIContainer.self) private var diContainer
+  @Environment(LocalTodoHelper.self) private var todoHelper
+  @Environment(LocalMemoHelper.self) private var memoHelper
 
   @AppStorage(UserDefaultsKey.cachedProfileName.rawValue)
   private var cachedProfileName: String = ""
@@ -23,29 +25,8 @@ struct Sidebar: View {
 
   @Binding var selection: NavigationDestination?
 
-  // Queries for counts
-  // Optimization: Only fetch what is needed for count if possible, but SwiftData loads models.
-  // We assume volume is manageable.
-  @Query(filter: #Predicate<SDTodo> { !$0.isDeleted }) private var allTodos: [SDTodo]
-  @Query(filter: #Predicate<SDMemo> { !$0.isDeleted }) private var allMemos: [SDMemo]
-
-  private var todayTodoCount: Int {
-    // Filter for today
-    let calendar = Calendar.current
-    return allTodos.count(where: { calendar.isDateInToday($0.date) })
-  }
-
-  private var memoCount: Int {
-    allMemos.count
-  }
-
-  private var hasGroup: Bool {
-    !cachedUserGroupId.isEmpty
-  }
-
-  private var groupName: String {
-    (cachedGroupName.isEmpty ? nil : cachedGroupName) ?? "그룹"
-  }
+  @State private var todayTodoCount: Int = 0
+  @State private var memoCount: Int = 0
 
   var body: some View {
     List(selection: $selection) {
@@ -119,6 +100,9 @@ struct Sidebar: View {
     }
     .frame(minWidth: 200)
     .listStyle(.sidebar)
+    .task(id: [todoHelper.refreshClock, memoHelper.refreshClock]) {
+      await refreshCounts()
+    }
   }
 
   private var groupLabel: some View {
@@ -140,12 +124,42 @@ struct Sidebar: View {
         .foregroundStyle(.secondary)
     }
   }
+
+  private var hasGroup: Bool {
+    !cachedUserGroupId.isEmpty
+  }
+
+  private var groupName: String {
+    (cachedGroupName.isEmpty ? nil : cachedGroupName) ?? "그룹"
+  }
+
+  private func refreshCounts() async {
+    let calendar = Calendar.current
+    let now = Date()
+    let startOfDay = calendar.startOfDay(for: now)
+
+    // TODO: All todos for today
+    if let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)?.addingTimeInterval(
+      -1) {
+      let query = TodoQuery(filters: [.dateRange(startOfDay ... endOfDay)])
+      if let count = try? await diContainer.core.fetchTodoCountUseCase.execute(query: query) {
+        todayTodoCount = count
+      }
+    }
+
+    // Memo: All memos
+    if let count = try? await diContainer.core.fetchMemoCountUseCase.execute(userId: "") {
+      memoCount = count
+    }
+  }
 }
 
 #Preview {
   NavigationSplitView {
     Sidebar(selection: .constant(.todo))
       .environment(AppDIContainer.preview)
+      .environment(LocalTodoHelper.preview)
+      .environment(LocalMemoHelper.preview)
   } detail: {
     Text("Detail")
   }

--- a/TodoMate/Models/LocalMemoHelper.swift
+++ b/TodoMate/Models/LocalMemoHelper.swift
@@ -14,6 +14,8 @@ import TodoMateDomain
 @Observable
 @MainActor
 final class LocalMemoHelper {
+  var refreshClock: Int = 0
+
   // MARK: - Dependencies
 
   private let createUseCase: CreateLocalMemoUseCase
@@ -53,6 +55,7 @@ final class LocalMemoHelper {
     Task {
       do {
         try await createUseCase.run(memo)
+        refreshClock = (refreshClock + 1) % 100_000_000
       } catch {
         Log.error("Failed to create private memo: \(error)", category: .data)
       }
@@ -65,6 +68,7 @@ final class LocalMemoHelper {
     Task {
       do {
         try await updateUseCase.run(updatedMemo)
+        refreshClock = (refreshClock + 1) % 100_000_000
       } catch {
         Log.error("Failed to update private memo: \(error)", category: .data)
       }
@@ -75,6 +79,7 @@ final class LocalMemoHelper {
     Task {
       do {
         try await deleteUseCase.run(memo)
+        refreshClock = (refreshClock + 1) % 100_000_000
       } catch {
         Log.error("Failed to delete private memo: \(error)", category: .data)
       }

--- a/TodoMate/Models/LocalTodoHelper.swift
+++ b/TodoMate/Models/LocalTodoHelper.swift
@@ -14,6 +14,8 @@ import TodoMateDomain
 @Observable
 @MainActor
 final class LocalTodoHelper {
+  var refreshClock: Int = 0
+
   private let createUseCase: CreateLocalTodoUseCase
   private let readUseCase: ReadLocalTodoUseCase
   private let updateUseCase: UpdateLocalTodoUseCase
@@ -48,6 +50,7 @@ final class LocalTodoHelper {
     Task {
       do {
         try await createUseCase.run(todo)
+        refreshClock = (refreshClock + 1) % 100_000_000
       } catch {
         self.error = error
         Log.error("Failed to create local todo: \(error)")
@@ -59,6 +62,7 @@ final class LocalTodoHelper {
     Task {
       do {
         try await updateUseCase.run(todo)
+        refreshClock = (refreshClock + 1) % 100_000_000
       } catch {
         self.error = error
         Log.error("Failed to update local todo: \(error)")
@@ -78,6 +82,7 @@ final class LocalTodoHelper {
     Task {
       do {
         try await deleteUseCase.run(todoId)
+        refreshClock = (refreshClock + 1) % 100_000_000
       } catch {
         self.error = error
         Log.error("Failed to delete local todo: \(error)")

--- a/TodoMateData/Sources/TodoMateData/LocalMemoRepositoryImpl.swift
+++ b/TodoMateData/Sources/TodoMateData/LocalMemoRepositoryImpl.swift
@@ -48,7 +48,8 @@ public actor SwiftDataMemoRepositoryImpl: MemoRepository {
 
     do {
       if let sdMemo = try modelContext.fetch(descriptor).first {
-        modelContext.delete(sdMemo)
+        sdMemo.isDeleted = true
+        sdMemo.updatedAt = Date()
         try modelContext.save()
       }
     } catch {
@@ -57,7 +58,8 @@ public actor SwiftDataMemoRepositoryImpl: MemoRepository {
   }
 
   public func read(id: String) async throws -> Memo? {
-    let descriptor = FetchDescriptor<SDMemo>(predicate: #Predicate<SDMemo> { $0.id == id })
+    let descriptor = FetchDescriptor<SDMemo>(
+      predicate: #Predicate<SDMemo> { $0.id == id && !$0.isDeleted })
     do {
       return try modelContext.fetch(descriptor).first?.toDomain()
     } catch {
@@ -66,7 +68,10 @@ public actor SwiftDataMemoRepositoryImpl: MemoRepository {
   }
 
   public func readAllByUserId(_: String, useCache _: Bool) async throws -> [Memo] {
-    let descriptor = FetchDescriptor<SDMemo>(sortBy: [SortDescriptor(\.createdAt, order: .reverse)])
+    let descriptor = FetchDescriptor<SDMemo>(
+      predicate: #Predicate<SDMemo> { !$0.isDeleted },
+      sortBy: [SortDescriptor(\.createdAt, order: .reverse)],
+    )
     do {
       let sdMemos = try modelContext.fetch(descriptor)
       return sdMemos.map { $0.toDomain() }
@@ -77,5 +82,14 @@ public actor SwiftDataMemoRepositoryImpl: MemoRepository {
 
   public func readAllByUserIds(_: [String], useCache _: Bool) async throws -> [Memo] {
     []
+  }
+
+  public func fetchCount(userId _: String) async throws -> Int {
+    let descriptor = FetchDescriptor<SDMemo>(predicate: #Predicate<SDMemo> { !$0.isDeleted })
+    do {
+      return try modelContext.fetchCount(descriptor)
+    } catch {
+      throw SwiftDataError.fetchFailed(underlying: error)
+    }
   }
 }

--- a/TodoMateData/Sources/TodoMateData/LocalTodoRepositoryImpl.swift
+++ b/TodoMateData/Sources/TodoMateData/LocalTodoRepositoryImpl.swift
@@ -51,7 +51,8 @@ public actor SwiftDataTodoRepositoryImpl: TodoRepository {
     let descriptor = FetchDescriptor<SDTodo>(predicate: #Predicate { $0.id == todoId })
     do {
       if let existing = try modelContext.fetch(descriptor).first {
-        modelContext.delete(existing)
+        existing.isDeleted = true
+        existing.updatedAt = Date()
       }
     } catch {
       throw SwiftDataError.fetchFailed(underlying: error)
@@ -65,7 +66,7 @@ public actor SwiftDataTodoRepositoryImpl: TodoRepository {
   }
 
   public func read(id: String) async throws -> Todo? {
-    let descriptor = FetchDescriptor<SDTodo>(predicate: #Predicate { $0.id == id })
+    let descriptor = FetchDescriptor<SDTodo>(predicate: #Predicate { $0.id == id && !$0.isDeleted })
     do {
       return try modelContext.fetch(descriptor).first?.toDomain()
     } catch {
@@ -86,16 +87,47 @@ public actor SwiftDataTodoRepositoryImpl: TodoRepository {
       let start = dateRange.lowerBound
       let end = dateRange.upperBound
       descriptor = FetchDescriptor<SDTodo>(
-        predicate: #Predicate<SDTodo> { $0.date >= start && $0.date <= end },
+        predicate: #Predicate<SDTodo> { $0.date >= start && $0.date <= end && !$0.isDeleted },
         sortBy: [SortDescriptor(\.date)],
       )
     } else {
-      descriptor = FetchDescriptor<SDTodo>(sortBy: [SortDescriptor(\.date)])
+      descriptor = FetchDescriptor<SDTodo>(
+        predicate: #Predicate<SDTodo> { !$0.isDeleted },
+        sortBy: [SortDescriptor(\.date)],
+      )
     }
 
     do {
       let allSDTodos = try modelContext.fetch(descriptor)
       return allSDTodos.map { $0.toDomain() }
+    } catch {
+      throw SwiftDataError.fetchFailed(underlying: error)
+    }
+  }
+
+  public func fetchCount(query: TodoQuery) async throws -> Int {
+    var dateRange: ClosedRange<Date>?
+    for filter in query.filters {
+      if case let .dateRange(range) = filter {
+        dateRange = range
+      }
+    }
+
+    let descriptor: FetchDescriptor<SDTodo>
+    if let dateRange {
+      let start = dateRange.lowerBound
+      let end = dateRange.upperBound
+      descriptor = FetchDescriptor<SDTodo>(
+        predicate: #Predicate<SDTodo> { $0.date >= start && $0.date <= end && !$0.isDeleted },
+      )
+    } else {
+      descriptor = FetchDescriptor<SDTodo>(
+        predicate: #Predicate<SDTodo> { !$0.isDeleted },
+      )
+    }
+
+    do {
+      return try modelContext.fetchCount(descriptor)
     } catch {
       throw SwiftDataError.fetchFailed(underlying: error)
     }

--- a/TodoMateData/Sources/TodoMateData/MemoRepositoryImpl.swift
+++ b/TodoMateData/Sources/TodoMateData/MemoRepositoryImpl.swift
@@ -74,4 +74,15 @@ public final class FirestoreMemoRepository: MemoRepository {
       throw FirestoreRepositoryError.readFailed(underlying: error)
     }
   }
+
+  public func fetchCount(userId: String) async throws -> Int {
+    do {
+      let snapshot = try await reference.memoCollection()
+        .whereField("owner", isEqualTo: userId)
+        .count.getAggregation(source: .server)
+      return Int(truncating: snapshot.count)
+    } catch {
+      throw FirestoreRepositoryError.readFailed(underlying: error)
+    }
+  }
 }

--- a/TodoMateData/Sources/TodoMateData/TodoRepositoryImpl.swift
+++ b/TodoMateData/Sources/TodoMateData/TodoRepositoryImpl.swift
@@ -58,6 +58,16 @@ public final class FirestoreTodoRepository: TodoRepository {
     }
   }
 
+  public func fetchCount(query: TodoQuery) async throws -> Int {
+    let firestoreQuery = buildFirestoreQuery(from: query)
+    do {
+      let snapshot = try await firestoreQuery.count.getAggregation(source: .server)
+      return Int(truncating: snapshot.count)
+    } catch {
+      throw FirestoreRepositoryError.readFailed(underlying: error)
+    }
+  }
+
   private func buildFirestoreQuery(from todoQuery: TodoQuery) -> Query {
     var firestoreQuery: Query = reference.todoCollection()
 

--- a/TodoMateData/Tests/TodoMateDataTests/LocalMemoRepositoryTests.swift
+++ b/TodoMateData/Tests/TodoMateDataTests/LocalMemoRepositoryTests.swift
@@ -69,4 +69,38 @@ struct LocalMemoRepositoryTests {
     let results = try await repository.readAllByUserId(testUserId, useCache: false)
     #expect(!results.contains { $0.id == memo.id })
   }
+
+  // MARK: - Fetch Count
+
+  @Test("Fetches memo count respecting isDeleted")
+  func fetchCount() async throws {
+    let now = Date()
+
+    // 1. One active
+    let memo1 = Memo(
+      id: UUID().uuidString,
+      content: "Active",
+      createdAt: now,
+      updatedAt: now,
+      owner: testUserId,
+      isDeleted: false,
+    )
+
+    // 2. One deleted
+    let memo2 = Memo(
+      id: UUID().uuidString,
+      content: "Deleted",
+      createdAt: now,
+      updatedAt: now,
+      owner: testUserId,
+      isDeleted: true,
+    )
+
+    try await repository.create(memo1)
+    try await repository.create(memo2)
+
+    let count = try await repository.fetchCount(userId: testUserId)
+
+    #expect(count == 1)
+  }
 }

--- a/TodoMateData/Tests/TodoMateDataTests/LocalTodoRepositoryTests.swift
+++ b/TodoMateData/Tests/TodoMateDataTests/LocalTodoRepositoryTests.swift
@@ -75,4 +75,57 @@ struct LocalTodoRepositoryTests {
     let results = try await repository.readAll(query: query, useCache: true)
     #expect(!results.contains { $0.id == todo.id })
   }
+
+  // MARK: - Fetch Count
+
+  @Test("Fetches todo count with query and respects isDeleted")
+  func fetchCount() async throws {
+    let today = Date()
+    let calendar = Calendar.current
+    let startOfDay = calendar.startOfDay(for: today)
+    let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)!.addingTimeInterval(-1)
+
+    // 1. One active today
+    let todo1 = Todo(
+      id: UUID().uuidString,
+      content: "Active Today",
+      date: today,
+      createdAt: today,
+      updatedAt: today,
+      owner: testUserId,
+      isDeleted: false,
+    )
+
+    // 2. One deleted today
+    let todo2 = Todo(
+      id: UUID().uuidString,
+      content: "Deleted Today",
+      date: today,
+      createdAt: today,
+      updatedAt: today,
+      owner: testUserId,
+      isDeleted: true,
+    )
+
+    // 3. One active tomorrow (out of range)
+    let tomorrow = calendar.date(byAdding: .day, value: 1, to: today)!
+    let todo3 = Todo(
+      id: UUID().uuidString,
+      content: "Active Tomorrow",
+      date: tomorrow,
+      createdAt: tomorrow,
+      updatedAt: tomorrow,
+      owner: testUserId,
+      isDeleted: false,
+    )
+
+    try await repository.create(todo1)
+    try await repository.create(todo2)
+    try await repository.create(todo3)
+
+    let query = TodoQuery(filters: [.dateRange(startOfDay ... endOfDay)])
+    let count = try await repository.fetchCount(query: query)
+
+    #expect(count == 1)
+  }
 }

--- a/TodoMateDomain/Sources/TodoMateDomain/Protocol/MemoRepository.swift
+++ b/TodoMateDomain/Sources/TodoMateDomain/Protocol/MemoRepository.swift
@@ -12,6 +12,7 @@ public protocol MemoRepository: Sendable {
   func read(id: String) async throws -> Memo?
   func readAllByUserId(_ userId: String, useCache: Bool) async throws -> [Memo]
   func readAllByUserIds(_ userIds: [String], useCache: Bool) async throws -> [Memo]
+  func fetchCount(userId: String) async throws -> Int
 }
 
 // MARK: - StubMemoRepository
@@ -24,4 +25,5 @@ public final class StubMemoRepository: MemoRepository, Sendable {
   public func read(id _: String) async throws -> Memo? { nil }
   public func readAllByUserId(_: String, useCache _: Bool = true) async throws -> [Memo] { [] }
   public func readAllByUserIds(_: [String], useCache _: Bool = true) async throws -> [Memo] { [] }
+  public func fetchCount(userId _: String) async throws -> Int { 0 }
 }

--- a/TodoMateDomain/Sources/TodoMateDomain/Protocol/TodoRepository.swift
+++ b/TodoMateDomain/Sources/TodoMateDomain/Protocol/TodoRepository.swift
@@ -11,6 +11,7 @@ public protocol TodoRepository: Sendable {
   func delete(_ todoId: String) async throws
   func read(id: String) async throws -> Todo?
   func readAll(query: TodoQuery, useCache: Bool) async throws -> [Todo]
+  func fetchCount(query: TodoQuery) async throws -> Int
 }
 
 // MARK: - StubTodoRepository
@@ -22,4 +23,5 @@ public final class StubTodoRepository: TodoRepository, Sendable {
   public func delete(_: String) async throws {}
   public func read(id _: String) async throws -> Todo? { nil }
   public func readAll(query _: TodoQuery, useCache _: Bool) async throws -> [Todo] { [] }
+  public func fetchCount(query _: TodoQuery) async throws -> Int { 0 }
 }

--- a/TodoMateDomain/Sources/TodoMateDomain/UseCase/Memo/FetchMemoCountUseCase.swift
+++ b/TodoMateDomain/Sources/TodoMateDomain/UseCase/Memo/FetchMemoCountUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  FetchMemoCountUseCase.swift
+//  TodoMateDomain
+//
+//  Created by agent on 1/16/26.
+//
+
+import Foundation
+
+public protocol FetchMemoCountUseCase: Sendable {
+  func execute(userId: String) async throws -> Int
+}
+
+public final class FetchMemoCountUseCaseImpl: FetchMemoCountUseCase {
+  private let repository: MemoRepository
+
+  public init(repository: MemoRepository) {
+    self.repository = repository
+  }
+
+  public func execute(userId: String) async throws -> Int {
+    try await repository.fetchCount(userId: userId)
+  }
+}

--- a/TodoMateDomain/Sources/TodoMateDomain/UseCase/Todo/FetchTodoCountUseCase.swift
+++ b/TodoMateDomain/Sources/TodoMateDomain/UseCase/Todo/FetchTodoCountUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  FetchTodoCountUseCase.swift
+//  TodoMateDomain
+//
+//  Created by agent on 1/16/26.
+//
+
+import Foundation
+
+public protocol FetchTodoCountUseCase: Sendable {
+  func execute(query: TodoQuery) async throws -> Int
+}
+
+public final class FetchTodoCountUseCaseImpl: FetchTodoCountUseCase {
+  private let repository: TodoRepository
+
+  public init(repository: TodoRepository) {
+    self.repository = repository
+  }
+
+  public func execute(query: TodoQuery) async throws -> Int {
+    try await repository.fetchCount(query: query)
+  }
+}


### PR DESCRIPTION
## Description
This PR addresses issue #130 by optimizing the Sidebar count fetching mechanism and implementing Soft Delete for local data.

## Changes
- **Count Optimization**: Implemented `fetchCount` UseCases for Todo and Memo to avoid loading all entities into memory.
- **Reactive Updates**: Updated `Sidebar` to reactively refresh counts using `refreshClock` in `LocalTodoHelper` and `LocalMemoHelper`.
- **Soft Delete**: Implemented "Soft Delete" logic in `LocalTodoRepositoryImpl` and `LocalMemoRepositoryImpl`.
  - `delete` operation now sets `isDeleted = true` instead of removing the record.
  - Fetch operations now filter out items where `isDeleted == true`.
- **Testing**: Added unit tests for `fetchCount` and Soft Delete logic in `LocalTodoRepositoryTests` and `LocalMemoRepositoryTests`.

## Linked Issue
Closes #130