### PR TITLE
feat: URL Scheme 기반 윈도우 관리 구현 및 Debug 환경 분리

### DIFF
--- a/Common/Sources/Common/UserDefaultsKey.swift
+++ b/Common/Sources/Common/UserDefaultsKey.swift
@@ -25,6 +25,9 @@ public enum UserDefaultsKey: String {
   /// 채팅 패널 표시 상태
   case chatPanelVisibility = "chat_panel_visibility"
 
+  /// Dock 아이콘 표시 여부
+  case showInDock = "show_in_dock"
+
   /// Public 기능 활성화 여부
   case isPublicModeEnabled = "is_public_mode_enabled"
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -12,6 +12,16 @@
 				<string>com.googleusercontent.apps.937643864657-13cj5pccsikovhaqa4e4qivolanp9fd7</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>io.hotcs6.TodoMate</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>todomate</string>
+			</array>
+		</dict>
 	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>

--- a/Resources/InfoDebug.plist
+++ b/Resources/InfoDebug.plist
@@ -12,6 +12,16 @@
 				<string>com.googleusercontent.apps.921397175738-v6vuti9mi4va6erhgmdhoko79iv7ndup</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>io.hotcs6.TodoMate</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>todomatedebug</string>
+			</array>
+		</dict>
 	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>

--- a/TodoMate/Application/AppDelegate.swift
+++ b/TodoMate/Application/AppDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by hs on 6/27/25.
 //
 
+import Common
 import Sparkle
 import SwiftUI
 import TodoMateData
@@ -13,26 +14,27 @@ import WidgetKit
 final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, SPUUpdaterDelegate {
   var updater: SPUUpdater?
 
-  /// 앱 종료 시 호출될 cleanup 핸들러 (Store 정리용)
-  var cleanupHandler: (() -> Void)?
-
-  func applicationWillFinishLaunching(_: Notification) {
-    /// 새 윈도우 생성 메뉴 삭제
-    if let mainMenu = NSApplication.shared.mainMenu {
-      for item in mainMenu.items {
-        if item.title == "File", let submenu = item.submenu {
-          for (index, subItem) in submenu.items.enumerated() {
-            if subItem.title == "New Window" {
-              submenu.removeItem(at: index)
-              break
-            }
-          }
-        }
-      }
-    }
+  private var mainWindowURL: URL? {
+    #if DEBUG
+      URL(string: "todomatedebug://main")
+    #else
+      URL(string: "todomate://main")
+    #endif
   }
 
   func applicationDidFinishLaunching(_: Notification) {
+    // Dock 표시 설정 적용 (기본값: true/regular)
+    let showInDock = UserDefaults.standard.bool(
+      for: .showInDock,
+      default: true,
+    )
+    NSApp.setActivationPolicy(showInDock ? .regular : .accessory)
+
+    // 앱 실행 시 Main Window 강제 오픈 (LSUIElement 대응)
+    if let url = mainWindowURL {
+      NSWorkspace.shared.open(url)
+    }
+
     #if !DEBUG
       /// Sparkle Controller 설정
       let updaterController = SPUStandardUpdaterController(
@@ -51,9 +53,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, SPUU
   }
 
   func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-    // 앱 종료 전 모든 리스너/스트림 정리
-    cleanupHandler?()
-
     // Firestore gRPC 연결 종료 후 앱 종료
     Task { @MainActor in
       do {
@@ -72,11 +71,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, SPUU
 
   func applicationShouldHandleReopen(_: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
     if !flag {
-      for window in NSApplication.shared.windows {
-        // Status Bar Window 등 시스템 윈도우 제외하고 메인 윈도우만 찾아서 활성화
-        if window.canBecomeKey, window.isVisible == false {
-          window.makeKeyAndOrderFront(nil)
-        }
+      if let url = mainWindowURL {
+        NSWorkspace.shared.open(url)
       }
     }
     return true

--- a/TodoMate/Application/TodoMateApp.swift
+++ b/TodoMate/Application/TodoMateApp.swift
@@ -91,8 +91,9 @@ struct TodoMateApp: App {
           #endif
         }
     }
+    .handlesExternalEvents(matching: [AppSceneID.mainApp.rawValue])
     #if os(macOS)
-    .windowStyle(.hiddenTitleBar)
+      .windowStyle(.hiddenTitleBar)
     #endif
   }
 }

--- a/TodoMate/Features/Public/Setting/SettingView.swift
+++ b/TodoMate/Features/Public/Setting/SettingView.swift
@@ -14,6 +14,8 @@ struct SettingView: View {
   @Environment(SessionStore.self) private var sessionStore
   @AppStorage(UserDefaultsKey.isPublicModeEnabled.rawValue)
   private var isPublicModeEnabled: Bool = false
+  @AppStorage(UserDefaultsKey.showInDock.rawValue)
+  private var showInDock: Bool = true
   @State private var showLogoutConfirmation = false
   @State private var showLeaveGroupConfirmation = false
   @State private var showEditNameSheet = false
@@ -31,6 +33,7 @@ struct SettingView: View {
     ScrollView {
       VStack(spacing: 30) {
         profileSection
+        dockSection
         if sessionStore.user != nil {
           groupSection
         }
@@ -82,6 +85,35 @@ struct SettingView: View {
           }
         },
       )
+    }
+  }
+
+  // MARK: - Dock Section
+
+  private var dockSection: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text("General")
+        .font(.headline)
+        .foregroundStyle(.secondary)
+
+      VStack(alignment: .leading, spacing: 12) {
+        Toggle("Dock에 표시", isOn: $showInDock)
+          .toggleStyle(.switch)
+
+        Text("앱을 다시 실행하지 않아도 즉시 반영됩니다.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+      .padding(16)
+      .background(Color(nsColor: .controlBackgroundColor))
+      .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+    .onChange(of: showInDock) { _, newValue in
+      NSApp.setActivationPolicy(newValue ? .regular : .accessory)
+      if newValue {
+        // Dock에 표시될 때, 필요하면 앱을 활성화하여 윈도우가 앞으로 오게 할 수도 있음
+        NSApp.activate(ignoringOtherApps: true)
+      }
     }
   }
 


### PR DESCRIPTION
## 변경 목적
* 기존의 NSApplication 윈도우 순회 방식 대신, URL Scheme(todomate://)을 활용하여 메인 윈도우를 명시적으로 열고 활성화하도록 개선했습니다.
* Debug 빌드와 Release 빌드가 동시에 설치되어 있을 때 URL Scheme 충돌을 방지하기 위해 환경을 분리했습니다.

## 주요 변경 사항

### 1. URL Scheme 도입 및 윈도우 제어 로직 변경
* Info.plist(Release)와 InfoDebug.plist(Debug)에 각각 todomate와 todomatedebug URL Scheme을 등록했습니다.
* AppDelegate: 앱 실행 시(didFinishLaunching)와 재진입 시(shouldHandleReopen) NSWorkspace.shared.open(url)을 호출하여 메인 윈도우를 엽니다.
* TodoMateApp: WindowGroup에 .handlesExternalEvents를 추가하여 URL 이벤트를 수신하고 해당 윈도우를 활성화하도록 연결했습니다.
* 기존의 불필요한 "New Window" 메뉴 삭제 코드와 윈도우 수동 활성화 코드를 제거했습니다.

### 2. Debug 환경 분리
* Debug 빌드는 todomatedebug:// 스킴을 사용하도록 설정하여, 실기기/시뮬레이터에서 Release 앱과 충돌 없이 공존할 수 있도록 했습니다.

### 3. 기타
* UserDefaultsKey: 추후 Dock 아이콘 제어를 위한 showInDock 키를 추가했습니다.
* cleanupHandler 등 미사용 코드를 정리했습니다.

Closes #133