### PR TITLE
Migrate local data persistence from SwiftData to GRDB

### DIFF
--- a/TodoMate/Application/Dependency/CoreDIContainer.swift
+++ b/TodoMate/Application/Dependency/CoreDIContainer.swift
@@ -6,14 +6,13 @@
 //
 
 import Foundation
-import SwiftData
 import TodoMateData
 import TodoMateDomain
 
 @Observable
 @MainActor
 final class CoreDIContainer {
-  @ObservationIgnored let modelContainer: ModelContainer
+  @ObservationIgnored let database: GRDBDatabase
   @ObservationIgnored let userDefaults: UserDefaults
   @ObservationIgnored let calendar: Calendar
   @ObservationIgnored let hotKeyManager: HotKeyManager
@@ -49,19 +48,19 @@ final class CoreDIContainer {
   @ObservationIgnored let legacyImportStateRepository: LegacyImportStateRepository
 
   init(
-    modelContainer: ModelContainer,
+    database: GRDBDatabase,
     userDefaults: UserDefaults = .standard,
     calendar: Calendar = .current,
     hotKeyManager: HotKeyManager,
   ) {
-    self.modelContainer = modelContainer
+    self.database = database
     self.userDefaults = userDefaults
     self.calendar = calendar
     self.hotKeyManager = hotKeyManager
     calendarDayService = CalendarDayServiceImpl(calendar: calendar)
 
-    localTodoRepository = SwiftDataTodoRepositoryImpl(modelContainer: modelContainer)
-    localMemoRepository = SwiftDataMemoRepositoryImpl(modelContainer: modelContainer)
+    localTodoRepository = GRDBTodoRepositoryImpl(dbWriter: database.dbWriter)
+    localMemoRepository = GRDBMemoRepositoryImpl(dbWriter: database.dbWriter)
 
     createLocalTodoUseCase = CreateLocalTodoUseCaseImpl(repository: localTodoRepository)
     readLocalTodoUseCase = ReadLocalTodoUseCaseImpl(
@@ -85,7 +84,7 @@ final class CoreDIContainer {
     sidebarCacheUseCase = SidebarCacheUseCaseImpl(repository: sidebarCacheRepository)
 
     // Deleted Items
-    deletedItemsRepository = DeletedItemsRepositoryImpl(modelContainer: modelContainer)
+    deletedItemsRepository = GRDBDeletedItemsRepositoryImpl(dbWriter: database.dbWriter)
     fetchDeletedItemsUseCase = FetchDeletedItemsUseCaseImpl(repository: deletedItemsRepository)
     restoreDeletedItemUseCase = RestoreDeletedItemUseCaseImpl(repository: deletedItemsRepository)
     permanentlyDeleteItemUseCase = PermanentlyDeleteItemUseCaseImpl(
@@ -100,12 +99,10 @@ final class CoreDIContainer {
 extension CoreDIContainer {
   @MainActor
   static var preview: CoreDIContainer = {
-    let schema = Schema([SDTodo.self, SDMemo.self])
-    let config = ModelConfiguration(isStoredInMemoryOnly: true)
     // swiftlint:disable:next force_try
-    let container = try! ModelContainer(for: schema, configurations: [config])
+    let database = try! GRDBDatabase(inMemory: true)
     return CoreDIContainer(
-      modelContainer: container,
+      database: database,
       userDefaults: .preview,
       hotKeyManager: HotKeyManager(),
     )

--- a/TodoMate/Application/TodoMateApp+Debug.swift
+++ b/TodoMate/Application/TodoMateApp+Debug.swift
@@ -7,7 +7,7 @@
 
 #if DEBUG
   import Common
-  import SwiftData
+  import GRDB
   import SwiftUI
   import TodoMateData
   import TodoMateDomain
@@ -63,74 +63,83 @@
 
   enum MockDataSeeder {
     @MainActor
-    static func seedIfNeeded(container: ModelContainer) {
+    static func seedIfNeeded(database: GRDBDatabase) {
       guard DebugConfiguration.isUsingMock else { return }
 
-      let context = container.mainContext
-      let todoDescriptor = FetchDescriptor<SDTodo>()
+      Task {
+        do {
+          try await database.dbWriter.write { db in
+            if try GRDBTodo.fetchCount(db) > 0 { return }
 
-      do {
-        if try context.fetchCount(todoDescriptor) > 0 { return }
+            let today = Date()
+            let calendar = Calendar.current
 
-        let today = Date()
-        let calendar = Calendar.current
+            let todo1 = GRDBTodo(
+              id: UUID().uuidString,
+              content: "Buy Groceries",
+              statusRawValue: "todo",
+              detail: "",
+              date: today,
+              createdAt: today,
+              updatedAt: today,
+              owner: "user_1",
+              isDeleted: false
+            )
 
-        let todo1 = SDTodo(
-          content: "Buy Groceries",
-          status: "todo",
-          detail: "",
-          date: today,
-          createdAt: today,
-          updatedAt: today,
-          owner: "user_1",
-        )
+            let todo2 = GRDBTodo(
+              id: UUID().uuidString,
+              content: "Team Meeting",
+              statusRawValue: "done",
+              detail: "Prepare quarterly report",
+              date: today,
+              createdAt: today,
+              updatedAt: today,
+              owner: "user_1",
+              isDeleted: false
+            )
 
-        let todo2 = SDTodo(
-          content: "Team Meeting",
-          status: "done",
-          detail: "Prepare quarterly report",
-          date: today,
-          createdAt: today,
-          updatedAt: today,
-          owner: "user_1",
-        )
+            let todo3 = GRDBTodo(
+              id: UUID().uuidString,
+              content: "Walk the dog",
+              statusRawValue: "todo",
+              detail: "",
+              date: calendar.date(byAdding: .day, value: 1, to: today) ?? today,
+              createdAt: today,
+              updatedAt: today,
+              owner: "user_1",
+              isDeleted: false
+            )
 
-        let todo3 = SDTodo(
-          content: "Walk the dog",
-          status: "todo",
-          detail: "",
-          date: calendar.date(byAdding: .day, value: 1, to: today) ?? today,
-          createdAt: today,
-          updatedAt: today,
-          owner: "user_1",
-        )
+            try todo1.insert(db)
+            try todo2.insert(db)
+            try todo3.insert(db)
 
-        context.insert(todo1)
-        context.insert(todo2)
-        context.insert(todo3)
+            let memo1 = GRDBMemo(
+              id: UUID().uuidString,
+              content: "Project Ideas\n\n1. AI Assistant\n2. Smart Home",
+              createdAt: today,
+              updatedAt: today,
+              ownerId: "user_1",
+              isDeleted: false
+            )
 
-        let memo1 = SDMemo(
-          content: "Project Ideas\n\n1. AI Assistant\n2. Smart Home",
-          createdAt: today,
-          updatedAt: today,
-          ownerId: "user_1",
-        )
+            let memo2 = GRDBMemo(
+              id: UUID().uuidString,
+              content: "Shopping List\n- Milk\n- Eggs\n- Bread",
+              createdAt: calendar.date(byAdding: .day, value: -1, to: today) ?? today,
+              updatedAt: today,
+              ownerId: "user_1",
+              isDeleted: false
+            )
 
-        let memo2 = SDMemo(
-          content: "Shopping List\n- Milk\n- Eggs\n- Bread",
-          createdAt: calendar.date(byAdding: .day, value: -1, to: today) ?? today,
-          updatedAt: today,
-          ownerId: "user_1",
-        )
+            try memo1.insert(db)
+            try memo2.insert(db)
+          }
+          print("✅ Mock data seeded successfully")
 
-        context.insert(memo1)
-        context.insert(memo2)
-
-        try context.save()
-        print("✅ Mock data seeded successfully")
-
-      } catch {
-        print("❌ Failed to seed mock data: \(error)")
+        } catch {
+          print("❌ Failed to seed mock data: \(error)")
+        }
       }
     }
   }

--- a/TodoMate/Application/TodoMateApp.swift
+++ b/TodoMate/Application/TodoMateApp.swift
@@ -7,7 +7,6 @@
 
 import AppIntents
 import Common
-import SwiftData
 import SwiftUI
 import TodoMateData
 import TodoMateDomain
@@ -59,7 +58,6 @@ struct TodoMateApp: App {
     MenuBarExtra("TodoMate", systemImage: "checklist") {
       MenuBarView()
         .environment(todoBoardStore)
-        .modelContainer(appDIContainer.core.modelContainer)
     }
     .menuBarExtraStyle(.menu)
 
@@ -68,7 +66,6 @@ struct TodoMateApp: App {
     Window("TodoMate", id: AppSceneID.mainApp.rawValue) {
       MainView(container: appDIContainer)
         .defaultAppStorage(appDIContainer.core.userDefaults)
-        .modelContainer(appDIContainer.core.modelContainer)
         .environment(appDIContainer.core)
         .environment(todoBoardStore)
         .environment(memoStore)
@@ -78,7 +75,7 @@ struct TodoMateApp: App {
         .frame(minWidth: 1000, minHeight: 625)
         .task {
           #if DEBUG
-            MockDataSeeder.seedIfNeeded(container: appDIContainer.core.modelContainer)
+            MockDataSeeder.seedIfNeeded(database: appDIContainer.core.database)
           #endif
         }
     }
@@ -137,10 +134,17 @@ private extension TodoMateApp {
     userDefaults: UserDefaults,
     hotKeyManager: HotKeyManager,
   ) -> CoreDIContainer {
-    let container = Self.createSwiftDataModelContainer()
+    let database: GRDBDatabase
+    do {
+      database = try GRDBDatabase()
+      Log.info("GRDB Database created successfully.")
+    } catch {
+      Log.error("Failed to create GRDB Database: \(error)")
+      fatalError("Failed to create GRDB Database: \(error)")
+    }
 
     return CoreDIContainer(
-      modelContainer: container,
+      database: database,
       userDefaults: userDefaults,
       hotKeyManager: hotKeyManager,
     )
@@ -168,24 +172,6 @@ private extension TodoMateApp {
       authService: authService,
       messageReadTracker: messageReadTracker,
     )
-  }
-
-  static func createSwiftDataModelContainer() -> ModelContainer {
-    let schema = Schema([SDTodo.self, SDMemo.self])
-    let config = ModelConfiguration(
-      AppEnvironment.Container.name,
-      schema: schema,
-      isStoredInMemoryOnly: false,
-    )
-
-    do {
-      let container = try ModelContainer(for: schema, configurations: [config])
-      Log.info("SwiftData ModelContainer created successfully.")
-      return container
-    } catch {
-      Log.error("Failed to create SwiftData ModelContainer: \(error)")
-      fatalError("Failed to create ModelContainer: \(error)")
-    }
   }
 }
 

--- a/TodoMate/Features/MenuBar/MenuBarView.swift
+++ b/TodoMate/Features/MenuBar/MenuBarView.swift
@@ -8,7 +8,6 @@
 
 import AppKit
 import Common
-import SwiftData
 import SwiftUI
 import TodoMateDomain
 

--- a/TodoMateData/Package.swift
+++ b/TodoMateData/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
     .package(path: "../Common"),
     .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "12.7.0"),
     .package(url: "https://github.com/google/GoogleSignIn-iOS.git", from: "9.0.0"),
+    .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.0.0"),
   ],
   targets: [
     .target(
@@ -27,6 +28,7 @@ let package = Package(
         .product(name: "FirebaseAuth", package: "firebase-ios-sdk"),
         .product(name: "FirebaseFirestore", package: "firebase-ios-sdk"),
         .product(name: "GoogleSignIn", package: "GoogleSignIn-iOS"),
+        .product(name: "GRDB", package: "GRDB.swift"),
       ],
     ),
     // SwiftData 등 Firebase 외 Data 레이어 테스트

--- a/TodoMateData/Sources/TodoMateData/GRDB/GRDBDatabase.swift
+++ b/TodoMateData/Sources/TodoMateData/GRDB/GRDBDatabase.swift
@@ -1,0 +1,58 @@
+import Foundation
+import GRDB
+import Common
+
+public final class GRDBDatabase: Sendable {
+  public let dbWriter: any DatabaseWriter
+
+  public init(inMemory: Bool = false) throws {
+    if inMemory {
+      dbWriter = try DatabaseQueue()
+    } else {
+      let fileManager = FileManager.default
+      let appSupportURL = try fileManager.url(
+        for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+      let directoryURL = appSupportURL.appendingPathComponent("TodoMate", isDirectory: true)
+      try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+      let databaseURL = directoryURL.appendingPathComponent("db.sqlite")
+
+      var config = Configuration()
+      config.prepareDatabase { db in
+          // db.trace { print($0) } // Uncomment for debugging
+      }
+
+      dbWriter = try DatabasePool(path: databaseURL.path, configuration: config)
+    }
+
+    try migrator.migrate(dbWriter)
+  }
+
+  private var migrator: DatabaseMigrator {
+    var migrator = DatabaseMigrator()
+
+    migrator.registerMigration("v1") { db in
+      try db.create(table: "todo") { t in
+        t.column("id", .text).primaryKey()
+        t.column("content", .text).notNull()
+        t.column("statusRawValue", .text).notNull()
+        t.column("detail", .text).notNull()
+        t.column("date", .datetime).notNull()
+        t.column("createdAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+        t.column("owner", .text).notNull()
+        t.column("isDeleted", .boolean).notNull().defaults(to: false)
+      }
+
+      try db.create(table: "memo") { t in
+        t.column("id", .text).primaryKey()
+        t.column("content", .text).notNull()
+        t.column("createdAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+        t.column("ownerId", .text).notNull()
+        t.column("isDeleted", .boolean).notNull().defaults(to: false)
+      }
+    }
+
+    return migrator
+  }
+}

--- a/TodoMateData/Sources/TodoMateData/GRDB/Models/GRDBMemo.swift
+++ b/TodoMateData/Sources/TodoMateData/GRDB/Models/GRDBMemo.swift
@@ -1,0 +1,34 @@
+import Foundation
+import GRDB
+import TodoMateDomain
+
+public struct GRDBMemo: Codable, FetchableRecord, PersistableRecord, Sendable {
+  public var id: String
+  public var content: String
+  public var createdAt: Date
+  public var updatedAt: Date
+  public var ownerId: String
+  public var isDeleted: Bool
+
+  public static let databaseTableName = "memo"
+
+  public init(from memo: Memo) {
+    self.id = memo.id
+    self.content = memo.content
+    self.createdAt = memo.createdAt
+    self.updatedAt = memo.updatedAt
+    self.ownerId = memo.owner
+    self.isDeleted = memo.isDeleted
+  }
+
+  public func toDomain() -> Memo {
+    Memo(
+      id: id,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      owner: ownerId,
+      isDeleted: isDeleted
+    )
+  }
+}

--- a/TodoMateData/Sources/TodoMateData/GRDB/Models/GRDBTodo.swift
+++ b/TodoMateData/Sources/TodoMateData/GRDB/Models/GRDBTodo.swift
@@ -1,0 +1,43 @@
+import Foundation
+import GRDB
+import TodoMateDomain
+
+public struct GRDBTodo: Codable, FetchableRecord, PersistableRecord, Sendable {
+  public var id: String
+  public var content: String
+  public var statusRawValue: String
+  public var detail: String
+  public var date: Date
+  public var createdAt: Date
+  public var updatedAt: Date
+  public var owner: String
+  public var isDeleted: Bool
+
+  public static let databaseTableName = "todo"
+
+  public init(from todo: Todo) {
+    self.id = todo.id
+    self.content = todo.content
+    self.statusRawValue = todo.status.rawValue
+    self.detail = todo.detail
+    self.date = todo.date
+    self.createdAt = todo.createdAt
+    self.updatedAt = todo.updatedAt
+    self.owner = todo.owner
+    self.isDeleted = todo.isDeleted
+  }
+
+  public func toDomain() -> Todo {
+    Todo(
+      id: id,
+      content: content,
+      status: TodoStatus(rawValue: statusRawValue) ?? .todo,
+      detail: detail,
+      date: date,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      owner: owner,
+      isDeleted: isDeleted
+    )
+  }
+}

--- a/TodoMateData/Sources/TodoMateData/GRDB/Repositories/GRDBDeletedItemsRepositoryImpl.swift
+++ b/TodoMateData/Sources/TodoMateData/GRDB/Repositories/GRDBDeletedItemsRepositoryImpl.swift
@@ -1,0 +1,69 @@
+import Foundation
+import GRDB
+import TodoMateDomain
+
+public final class GRDBDeletedItemsRepositoryImpl: DeletedItemsRepository, Sendable {
+  private let dbWriter: any DatabaseWriter
+
+  public init(dbWriter: any DatabaseWriter) {
+    self.dbWriter = dbWriter
+  }
+
+  public func fetchAll() async throws -> [DeletedItem] {
+    try await dbWriter.read { db in
+      let deletedTodos = try GRDBTodo
+        .filter(Column("isDeleted"))
+        .fetchAll(db)
+        .map { DeletedItem.todo($0.toDomain()) }
+
+      let deletedMemos = try GRDBMemo
+        .filter(Column("isDeleted"))
+        .fetchAll(db)
+        .map { DeletedItem.memo($0.toDomain()) }
+
+      return (deletedTodos + deletedMemos).sorted { $0.deletedAt > $1.deletedAt }
+    }
+  }
+
+  public func restore(_ item: DeletedItem) async throws {
+    try await dbWriter.write { db in
+      switch item {
+      case let .todo(todo):
+        if var existing = try GRDBTodo.fetchOne(db, key: todo.id) {
+          existing.isDeleted = false
+          existing.updatedAt = Date()
+          try existing.update(db)
+        }
+      case let .memo(memo):
+        if var existing = try GRDBMemo.fetchOne(db, key: memo.id) {
+          existing.isDeleted = false
+          existing.updatedAt = Date()
+          try existing.update(db)
+        }
+      }
+    }
+  }
+
+  public func permanentlyDelete(_ item: DeletedItem) async throws {
+    try await dbWriter.write { db in
+      switch item {
+      case let .todo(todo):
+        try GRDBTodo.deleteOne(db, key: todo.id)
+      case let .memo(memo):
+        try GRDBMemo.deleteOne(db, key: memo.id)
+      }
+    }
+  }
+
+  public func permanentlyDeleteAll() async throws {
+    try await dbWriter.write { db in
+      try GRDBTodo
+        .filter(Column("isDeleted"))
+        .deleteAll(db)
+
+      try GRDBMemo
+        .filter(Column("isDeleted"))
+        .deleteAll(db)
+    }
+  }
+}

--- a/TodoMateData/Sources/TodoMateData/GRDB/Repositories/GRDBMemoRepositoryImpl.swift
+++ b/TodoMateData/Sources/TodoMateData/GRDB/Repositories/GRDBMemoRepositoryImpl.swift
@@ -1,0 +1,100 @@
+import Foundation
+import GRDB
+import TodoMateDomain
+
+public final class GRDBMemoRepositoryImpl: MemoRepository, Sendable {
+  private let dbWriter: any DatabaseWriter
+
+  public init(dbWriter: any DatabaseWriter) {
+    self.dbWriter = dbWriter
+  }
+
+  public func create(_ memo: Memo) async throws {
+    let grdbMemo = GRDBMemo(from: memo)
+    try await dbWriter.write { db in
+      try grdbMemo.insert(db)
+    }
+  }
+
+  public func update(_ memo: Memo) async throws {
+    let grdbMemo = GRDBMemo(from: memo)
+    try await dbWriter.write { db in
+      if try GRDBMemo.exists(db, key: memo.id) {
+        try grdbMemo.update(db)
+      } else {
+        try grdbMemo.insert(db)
+      }
+    }
+  }
+
+  public func delete(_ memo: Memo) async throws {
+    try await dbWriter.write { db in
+      if var existing = try GRDBMemo.fetchOne(db, key: memo.id) {
+        existing.isDeleted = true
+        existing.updatedAt = Date()
+        try existing.update(db)
+      }
+    }
+  }
+
+  public func read(id: String) async throws -> Memo? {
+    try await dbWriter.read { db in
+      try GRDBMemo
+        .filter(Column("id") == id && !Column("isDeleted"))
+        .fetchOne(db)?
+        .toDomain()
+    }
+  }
+
+  public func readAllByUserId(_ userId: String, useCache: Bool) async throws -> [Memo] {
+    // Note: userId is currently unused in the SwiftData implementation for local filter,
+    // it just fetches all non-deleted.
+    // However, the interface has userId.
+    // The SwiftData impl: `predicate: #Predicate<SDMemo> { !$0.isDeleted }`
+    // It ignores userId. I will follow the same behavior for now, or match SwiftData impl.
+    // "Let's use readAllByUserId with empty string as seen in Sidebar usage: diContainer.core.fetchMemoCountUseCase.execute(userId: "")"
+    // So it seems it just gets all local memos.
+
+    try await dbWriter.read { db in
+      try GRDBMemo
+        .filter(!Column("isDeleted"))
+        .order(Column("createdAt").desc)
+        .fetchAll(db)
+        .map { $0.toDomain() }
+    }
+  }
+
+  public func readAllByUserIds(_ userIds: [String], useCache: Bool) async throws -> [Memo] {
+    []
+  }
+
+  public func fetchCount(userId: String) async throws -> Int {
+    try await dbWriter.read { db in
+      try GRDBMemo
+        .filter(!Column("isDeleted"))
+        .fetchCount(db)
+    }
+  }
+
+  public func observeMemos() -> AsyncStream<[Memo]> {
+    let request = GRDBMemo
+      .filter(!Column("isDeleted"))
+      .order(Column("createdAt").desc)
+
+    let observation = ValueObservation.tracking { db in
+      try request.fetchAll(db).map { $0.toDomain() }
+    }
+
+    return AsyncStream { continuation in
+      let cancellable = observation.start(in: dbWriter, onError: { error in
+        print("GRDB Observation error: \(error)")
+      }, onChange: { memos in
+        continuation.yield(memos)
+      })
+
+      continuation.onTermination = { _ in
+        cancellable.cancel()
+      }
+    }
+  }
+}

--- a/TodoMateData/Sources/TodoMateData/GRDB/Repositories/GRDBTodoRepositoryImpl.swift
+++ b/TodoMateData/Sources/TodoMateData/GRDB/Repositories/GRDBTodoRepositoryImpl.swift
@@ -1,0 +1,100 @@
+import Foundation
+import GRDB
+import TodoMateDomain
+
+public final class GRDBTodoRepositoryImpl: TodoRepository, Sendable {
+  private let dbWriter: any DatabaseWriter
+
+  public init(dbWriter: any DatabaseWriter) {
+    self.dbWriter = dbWriter
+  }
+
+  public func create(_ todo: Todo) async throws {
+    let grdbTodo = GRDBTodo(from: todo)
+    try await dbWriter.write { db in
+      try grdbTodo.insert(db)
+    }
+  }
+
+  public func update(_ todo: Todo) async throws {
+    let grdbTodo = GRDBTodo(from: todo)
+    try await dbWriter.write { db in
+      try grdbTodo.update(db)
+    }
+  }
+
+  public func delete(_ todoId: String) async throws {
+    try await dbWriter.write { db in
+      // Soft delete as per SDTodo implementation
+      if var todo = try GRDBTodo.fetchOne(db, key: todoId) {
+        todo.isDeleted = true
+        todo.updatedAt = Date()
+        try todo.update(db)
+      }
+    }
+  }
+
+  public func read(id: String) async throws -> Todo? {
+    try await dbWriter.read { db in
+      try GRDBTodo
+        .filter(Column("id") == id && !Column("isDeleted"))
+        .fetchOne(db)?
+        .toDomain()
+    }
+  }
+
+  public func readAll(query: TodoQuery, useCache _: Bool) async throws -> [Todo] {
+    try await dbWriter.read { db in
+      try self.makeRequest(query: query)
+        .fetchAll(db)
+        .map { $0.toDomain() }
+    }
+  }
+
+  public func fetchCount(query: TodoQuery) async throws -> Int {
+    try await dbWriter.read { db in
+      try self.makeRequest(query: query).fetchCount(db)
+    }
+  }
+
+  public func observeTodos(query: TodoQuery) -> AsyncStream<[Todo]> {
+    let request = makeRequest(query: query)
+    let observation = ValueObservation.tracking { db in
+      try request.fetchAll(db).map { $0.toDomain() }
+    }
+
+    // Using immediate scheduling to mimic CurrentValueSubject behavior if needed,
+    // but default async is fine.
+
+    return AsyncStream { continuation in
+      let cancellable = observation.start(in: dbWriter, onError: { error in
+        print("GRDB Observation error: \(error)")
+      }, onChange: { todos in
+        continuation.yield(todos)
+      })
+
+      continuation.onTermination = { _ in
+        cancellable.cancel()
+      }
+    }
+  }
+
+  private func makeRequest(query: TodoQuery) -> QueryInterfaceRequest<GRDBTodo> {
+    var request = GRDBTodo
+      .filter(!Column("isDeleted"))
+      .order(Column("date"))
+
+    var dateRange: ClosedRange<Date>?
+    for filter in query.filters {
+      if case let .dateRange(range) = filter {
+        dateRange = range
+      }
+    }
+
+    if let dateRange {
+      request = request.filter(Column("date") >= dateRange.lowerBound && Column("date") <= dateRange.upperBound)
+    }
+
+    return request
+  }
+}

--- a/TodoMateData/Tests/TodoMateDataTests/PerformanceTests.swift
+++ b/TodoMateData/Tests/TodoMateDataTests/PerformanceTests.swift
@@ -1,0 +1,160 @@
+import XCTest
+import SwiftData
+import GRDB
+@testable import TodoMateData
+import TodoMateDomain
+
+final class PerformanceTests: XCTestCase {
+
+    // MARK: - SwiftData Setup
+    var modelContainer: ModelContainer!
+    var swiftDataRepository: SwiftDataTodoRepositoryImpl!
+
+    // MARK: - GRDB Setup
+    var dbQueue: DatabaseQueue!
+    var grdbRepository: GRDBTodoRepositoryImpl!
+
+    override func setUp() async throws {
+        // SwiftData Setup
+        let schema = Schema([SDTodo.self, SDMemo.self])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        modelContainer = try ModelContainer(for: schema, configurations: [config])
+        swiftDataRepository = SwiftDataTodoRepositoryImpl(modelContainer: modelContainer)
+
+        // GRDB Setup
+        dbQueue = try DatabaseQueue()
+        // Migration (Copied from GRDBDatabase.swift)
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration("v1") { db in
+            try db.create(table: "todo") { t in
+                t.column("id", .text).primaryKey()
+                t.column("content", .text).notNull()
+                t.column("statusRawValue", .text).notNull()
+                t.column("detail", .text).notNull()
+                t.column("date", .datetime).notNull()
+                t.column("createdAt", .datetime).notNull()
+                t.column("updatedAt", .datetime).notNull()
+                t.column("owner", .text).notNull()
+                t.column("isDeleted", .boolean).notNull().defaults(to: false)
+            }
+             try db.create(table: "memo") { t in
+                t.column("id", .text).primaryKey()
+                t.column("content", .text).notNull()
+                t.column("createdAt", .datetime).notNull()
+                t.column("updatedAt", .datetime).notNull()
+                t.column("ownerId", .text).notNull()
+                t.column("isDeleted", .boolean).notNull().defaults(to: false)
+              }
+        }
+        try migrator.migrate(dbQueue)
+        grdbRepository = GRDBTodoRepositoryImpl(dbWriter: dbQueue)
+    }
+
+    override func tearDown() {
+        modelContainer = nil
+        swiftDataRepository = nil
+        dbQueue = nil
+        grdbRepository = nil
+    }
+
+    func testPerformanceComparison() async throws {
+        print("\n=== Performance Benchmark: SwiftData vs GRDB (1,000 items) ===")
+
+        // --- SwiftData ---
+        print("\n[SwiftData]")
+        let sdCreateStart = Date()
+        for i in 0..<1000 {
+            let todo = Todo(
+                id: UUID().uuidString,
+                content: "Todo \(i)",
+                status: .todo,
+                detail: "Detail for todo \(i)",
+                date: Date(),
+                createdAt: Date(),
+                updatedAt: Date(),
+                owner: "user1",
+                isDeleted: false
+            )
+            try await swiftDataRepository.create(todo)
+        }
+        let sdCreateDuration = Date().timeIntervalSince(sdCreateStart)
+        print("Create: \(String(format: "%.4f", sdCreateDuration))s")
+
+        let sdReadStart = Date()
+        let sdTodos = try await swiftDataRepository.readAll(query: TodoQuery(filters: []), useCache: false)
+        let sdReadDuration = Date().timeIntervalSince(sdReadStart)
+        print("Read:   \(String(format: "%.4f", sdReadDuration))s (Count: \(sdTodos.count))")
+
+        let sdUpdateStart = Date()
+        for i in 0..<100 {
+            if var todo = sdTodos[safe: i] {
+                todo.status = .done
+                try await swiftDataRepository.update(todo)
+            }
+        }
+        let sdUpdateDuration = Date().timeIntervalSince(sdUpdateStart)
+        print("Update: \(String(format: "%.4f", sdUpdateDuration))s (100 items)")
+
+        let sdDeleteStart = Date()
+        for i in 0..<100 {
+            if let todo = sdTodos[safe: i] {
+                try await swiftDataRepository.delete(todo.id)
+            }
+        }
+        let sdDeleteDuration = Date().timeIntervalSince(sdDeleteStart)
+        print("Delete: \(String(format: "%.4f", sdDeleteDuration))s (100 items)")
+
+
+        // --- GRDB ---
+        print("\n[GRDB]")
+        let grdbCreateStart = Date()
+        for i in 0..<1000 {
+            let todo = Todo(
+                id: UUID().uuidString,
+                content: "Todo \(i)",
+                status: .todo,
+                detail: "Detail for todo \(i)",
+                date: Date(),
+                createdAt: Date(),
+                updatedAt: Date(),
+                owner: "user1",
+                isDeleted: false
+            )
+            try await grdbRepository.create(todo)
+        }
+        let grdbCreateDuration = Date().timeIntervalSince(grdbCreateStart)
+        print("Create: \(String(format: "%.4f", grdbCreateDuration))s")
+
+        let grdbReadStart = Date()
+        let grdbTodos = try await grdbRepository.readAll(query: TodoQuery(filters: []), useCache: false)
+        let grdbReadDuration = Date().timeIntervalSince(grdbReadStart)
+        print("Read:   \(String(format: "%.4f", grdbReadDuration))s (Count: \(grdbTodos.count))")
+
+        let grdbUpdateStart = Date()
+        for i in 0..<100 {
+            if var todo = grdbTodos[safe: i] {
+                todo.status = .done
+                try await grdbRepository.update(todo)
+            }
+        }
+        let grdbUpdateDuration = Date().timeIntervalSince(grdbUpdateStart)
+        print("Update: \(String(format: "%.4f", grdbUpdateDuration))s (100 items)")
+
+        let grdbDeleteStart = Date()
+        for i in 0..<100 {
+            if let todo = grdbTodos[safe: i] {
+                try await grdbRepository.delete(todo.id)
+            }
+        }
+        let grdbDeleteDuration = Date().timeIntervalSince(grdbDeleteStart)
+        print("Delete: \(String(format: "%.4f", grdbDeleteDuration))s (100 items)")
+
+        print("\n============================================================\n")
+    }
+}
+
+extension Collection {
+    subscript(safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}


### PR DESCRIPTION
Replaces SwiftData with GRDB for `SDTodo` and `SDMemo` persistence to improve performance.

Changes:
- Added `GRDB` dependency to `TodoMateData`.
- Implemented `GRDBDatabase` for SQLite management.
- Created `GRDBTodo` and `GRDBMemo` models.
- Implemented `GRDBTodoRepositoryImpl`, `GRDBMemoRepositoryImpl`, and `GRDBDeletedItemsRepositoryImpl`.
- Refactored `CoreDIContainer` and `TodoMateApp` to inject GRDB repositories.
- Updated `MockDataSeeder` to use GRDB.
- Added `PerformanceTests.swift` to compare SwiftData and GRDB performance (create, read, update, delete operations).

Note: The benchmark tests are ready in `TodoMateData/Tests/TodoMateDataTests/PerformanceTests.swift` and should be run on a macOS environment to verify performance improvements.

---
*PR created automatically by Jules for task [7285354420020529073](https://jules.google.com/task/7285354420020529073) started by @hot666666*